### PR TITLE
Updated gcc to version 4.9.2.

### DIFF
--- a/4.9/Dockerfile
+++ b/4.9/Dockerfile
@@ -9,7 +9,7 @@ RUN gpg --keyserver pgp.mit.edu --recv-key \
 	7F74F97C103468EE5D750B583AB00996FC26A641 \
 	33C235A34C46AA3FFB293709A328C3A2C3C45C06
 
-ENV GCC_VERSION 4.9.1
+ENV GCC_VERSION 4.9.2
 
 # "download_prerequisites" pulls down a bunch of tarballs and extracts them,
 # but then leaves the tarballs themselves lying around


### PR DESCRIPTION
GCC 4.9.2 was released on Thu, 30 Oct 2014.

See https://gcc.gnu.org/ml/gcc/2014-10/msg00259.html for more informations.
