### PR TITLE
Add support for cc, c89 and c99

### DIFF
--- a/4.6/Dockerfile
+++ b/4.6/Dockerfile
@@ -40,4 +40,4 @@ RUN apt-get update \
 RUN update-alternatives --remove cc /usr/bin/gcc \
 	&& unlink /usr/bin/gcc \
 	&& unlink /usr/bin/g++ \
-    && update-alternatives --install /usr/bin/cc cc /usr/local/bin/gcc 100
+	&& update-alternatives --install /usr/bin/cc cc /usr/local/bin/gcc 100

--- a/4.6/Dockerfile
+++ b/4.6/Dockerfile
@@ -34,4 +34,10 @@ RUN apt-get update \
 	&& make install-strip \
 	&& cd .. \
 	&& rm -rf "$dir" \
-	&& apt-get purge -y --auto-remove curl gcc g++ wget
+	&& apt-get purge -y --auto-remove curl wget
+
+# ensure that alternatives are pointing to the new compiler and that old one is no longer used
+RUN update-alternatives --remove cc /usr/bin/gcc \
+	&& unlink /usr/bin/gcc \
+	&& unlink /usr/bin/g++ \
+    && update-alternatives --install /usr/bin/cc cc /usr/local/bin/gcc 100

--- a/4.7/Dockerfile
+++ b/4.7/Dockerfile
@@ -40,4 +40,4 @@ RUN apt-get update \
 RUN update-alternatives --remove cc /usr/bin/gcc \
 	&& unlink /usr/bin/gcc \
 	&& unlink /usr/bin/g++ \
-    && update-alternatives --install /usr/bin/cc cc /usr/local/bin/gcc 100
+	&& update-alternatives --install /usr/bin/cc cc /usr/local/bin/gcc 100

--- a/4.7/Dockerfile
+++ b/4.7/Dockerfile
@@ -34,4 +34,10 @@ RUN apt-get update \
 	&& make install-strip \
 	&& cd .. \
 	&& rm -rf "$dir" \
-	&& apt-get purge -y --auto-remove curl gcc g++ wget
+	&& apt-get purge -y --auto-remove curl wget
+
+# ensure that alternatives are pointing to the new compiler and that old one is no longer used
+RUN update-alternatives --remove cc /usr/bin/gcc \
+	&& unlink /usr/bin/gcc \
+	&& unlink /usr/bin/g++ \
+    && update-alternatives --install /usr/bin/cc cc /usr/local/bin/gcc 100

--- a/4.8/Dockerfile
+++ b/4.8/Dockerfile
@@ -40,4 +40,4 @@ RUN apt-get update \
 RUN update-alternatives --remove cc /usr/bin/gcc \
 	&& unlink /usr/bin/gcc \
 	&& unlink /usr/bin/g++ \
-    && update-alternatives --install /usr/bin/cc cc /usr/local/bin/gcc 100
+	&& update-alternatives --install /usr/bin/cc cc /usr/local/bin/gcc 100

--- a/4.8/Dockerfile
+++ b/4.8/Dockerfile
@@ -34,4 +34,10 @@ RUN apt-get update \
 	&& make install-strip \
 	&& cd .. \
 	&& rm -rf "$dir" \
-	&& apt-get purge -y --auto-remove curl gcc g++ wget
+	&& apt-get purge -y --auto-remove curl wget
+
+# ensure that alternatives are pointing to the new compiler and that old one is no longer used
+RUN update-alternatives --remove cc /usr/bin/gcc \
+	&& unlink /usr/bin/gcc \
+	&& unlink /usr/bin/g++ \
+    && update-alternatives --install /usr/bin/cc cc /usr/local/bin/gcc 100

--- a/4.9/Dockerfile
+++ b/4.9/Dockerfile
@@ -40,4 +40,4 @@ RUN apt-get update \
 RUN update-alternatives --remove cc /usr/bin/gcc \
 	&& unlink /usr/bin/gcc \
 	&& unlink /usr/bin/g++ \
-    && update-alternatives --install /usr/bin/cc cc /usr/local/bin/gcc 100
+	&& update-alternatives --install /usr/bin/cc cc /usr/local/bin/gcc 100

--- a/4.9/Dockerfile
+++ b/4.9/Dockerfile
@@ -34,4 +34,10 @@ RUN apt-get update \
 	&& make install-strip \
 	&& cd .. \
 	&& rm -rf "$dir" \
-	&& apt-get purge -y --auto-remove curl gcc g++ wget
+	&& apt-get purge -y --auto-remove curl wget
+
+# ensure that alternatives are pointing to the new compiler and that old one is no longer used
+RUN update-alternatives --remove cc /usr/bin/gcc \
+	&& unlink /usr/bin/gcc \
+	&& unlink /usr/bin/g++ \
+    && update-alternatives --install /usr/bin/cc cc /usr/local/bin/gcc 100


### PR DESCRIPTION
As discussed in Issue #9 I need support for cc, c89 and c99. With this change, `gcc` inside the image should behave more like in any other official linux distro.
Although the initially installed `gcc` (version 4.7.2) is no longer purged, it is unlikely that a user of the image gets the "wrong" GCC. This is because the newly installed `gcc` is first in the `PATH` and the symlinks for `gcc` and `g++` in `/usr/bin/`get removed. 