### PR TITLE
Add gcc 5.1

### DIFF
--- a/5.1/Dockerfile
+++ b/5.1/Dockerfile
@@ -1,0 +1,48 @@
+FROM buildpack-deps:wheezy
+
+# https://gcc.gnu.org/mirrors.html
+ENV GPG_KEYS \
+	B215C1633BCA0477615F1B35A5B3A004745C015A \
+	B3C42148A44E6983B3E4CC0793FA9B1AB75C61B8 \
+	90AA470469D3965A87A5DCB494D03953902C9419 \
+	80F98B2E0DAB6C8281BDF541A7C8C3B2F71EDF1C \
+	7F74F97C103468EE5D750B583AB00996FC26A641 \
+	33C235A34C46AA3FFB293709A328C3A2C3C45C06
+RUN set -xe \
+	&& for key in $GPG_KEYS; do \
+		gpg --keyserver ha.pool.sks-keyservers.net --recv-keys "$key"; \
+	done
+
+ENV GCC_VERSION 5.1.0
+
+# "download_prerequisites" pulls down a bunch of tarballs and extracts them,
+# but then leaves the tarballs themselves lying around
+RUN buildDeps='flex' \
+	&& set -x \
+	&& apt-get update && apt-get install -y $buildDeps --no-install-recommends \
+	&& rm -r /var/lib/apt/lists/* \
+	&& curl -SL "http://ftpmirror.gnu.org/gcc/gcc-$GCC_VERSION/gcc-$GCC_VERSION.tar.bz2" -o gcc.tar.bz2 \
+	&& curl -SL "http://ftpmirror.gnu.org/gcc/gcc-$GCC_VERSION/gcc-$GCC_VERSION.tar.bz2.sig" -o gcc.tar.bz2.sig \
+	&& gpg --verify gcc.tar.bz2.sig \
+	&& mkdir -p /usr/src/gcc \
+	&& tar -xvf gcc.tar.bz2 -C /usr/src/gcc --strip-components=1 \
+	&& rm gcc.tar.bz2* \
+	&& cd /usr/src/gcc \
+	&& ./contrib/download_prerequisites \
+	&& { rm *.tar.* || true; } \
+	&& dir="$(mktemp -d)" \
+	&& cd "$dir" \
+	&& /usr/src/gcc/configure \
+		--disable-multilib \
+		--enable-languages=c,c++ \
+	&& make -j"$(nproc)" \
+	&& make install-strip \
+	&& cd .. \
+	&& rm -rf "$dir" \
+	&& apt-get purge -y --auto-remove $buildDeps
+
+# ensure that alternatives are pointing to the new compiler and that old one is no longer used
+RUN set -x \
+	&& dpkg-divert --divert /usr/bin/gcc.orig --rename /usr/bin/gcc \
+	&& dpkg-divert --divert /usr/bin/g++.orig --rename /usr/bin/g++ \
+	&& update-alternatives --install /usr/bin/cc cc /usr/local/bin/gcc 999

--- a/generate-stackbrew-library.sh
+++ b/generate-stackbrew-library.sh
@@ -3,7 +3,7 @@ set -e
 
 declare -A aliases
 aliases=(
-	[4.9]='latest'
+	[5.1]='latest'
 )
 
 cd "$(dirname "$(readlink -f "$BASH_SOURCE")")"


### PR DESCRIPTION
Currently building :smile:.
```diff
diff --git a/5.1/Dockerfile b/4.9/Dockerfile
index a8401b9..d424c0a 100644
--- a/5.1/Dockerfile
+++ b/4.9/Dockerfile
@@ -13,7 +13,7 @@ RUN set -xe \
                gpg --keyserver ha.pool.sks-keyservers.net --recv-keys "$key"; \
        done
 
-ENV GCC_VERSION 5.1.0
+ENV GCC_VERSION 4.9.2
 
 # "download_prerequisites" pulls down a bunch of tarballs and extracts them,
 # but then leaves the tarballs themselves lying around
```