### PR TITLE
Add EOL warning to update.sh (and switch to a different mirror with a date format that "date" is happy to parse)

### DIFF
--- a/4.6/Dockerfile
+++ b/4.6/Dockerfile
@@ -13,7 +13,7 @@ RUN set -xe \
 		gpg --keyserver ha.pool.sks-keyservers.net --recv-keys "$key"; \
 	done
 
-# Last Modified: 2013-Apr-12 12:50:10
+# Last Modified: 2013-04-12
 ENV GCC_VERSION 4.6.4
 
 # "download_prerequisites" pulls down a bunch of tarballs and extracts them,

--- a/4.6/Dockerfile
+++ b/4.6/Dockerfile
@@ -15,6 +15,7 @@ RUN set -xe \
 
 # Last Modified: 2013-04-12
 ENV GCC_VERSION 4.6.4
+# Docker EOL: 2015-04-12
 
 # "download_prerequisites" pulls down a bunch of tarballs and extracts them,
 # but then leaves the tarballs themselves lying around

--- a/4.7/Dockerfile
+++ b/4.7/Dockerfile
@@ -15,6 +15,7 @@ RUN set -xe \
 
 # Last Modified: 2014-06-12
 ENV GCC_VERSION 4.7.4
+# Docker EOL: 2016-06-12
 
 # "download_prerequisites" pulls down a bunch of tarballs and extracts them,
 # but then leaves the tarballs themselves lying around

--- a/4.7/Dockerfile
+++ b/4.7/Dockerfile
@@ -13,7 +13,7 @@ RUN set -xe \
 		gpg --keyserver ha.pool.sks-keyservers.net --recv-keys "$key"; \
 	done
 
-# Last Modified: 2014-Jun-12 14:36:11
+# Last Modified: 2014-06-12
 ENV GCC_VERSION 4.7.4
 
 # "download_prerequisites" pulls down a bunch of tarballs and extracts them,

--- a/4.8/Dockerfile
+++ b/4.8/Dockerfile
@@ -15,6 +15,7 @@ RUN set -xe \
 
 # Last Modified: 2014-12-19
 ENV GCC_VERSION 4.8.4
+# Docker EOL: 2016-12-19
 
 # "download_prerequisites" pulls down a bunch of tarballs and extracts them,
 # but then leaves the tarballs themselves lying around

--- a/4.8/Dockerfile
+++ b/4.8/Dockerfile
@@ -13,7 +13,7 @@ RUN set -xe \
 		gpg --keyserver ha.pool.sks-keyservers.net --recv-keys "$key"; \
 	done
 
-# Last Modified: 2014-Dec-19 08:06:16
+# Last Modified: 2014-12-19
 ENV GCC_VERSION 4.8.4
 
 # "download_prerequisites" pulls down a bunch of tarballs and extracts them,

--- a/4.9/Dockerfile
+++ b/4.9/Dockerfile
@@ -13,7 +13,7 @@ RUN set -xe \
 		gpg --keyserver ha.pool.sks-keyservers.net --recv-keys "$key"; \
 	done
 
-# Last Modified: 2014-Oct-30 06:01:09
+# Last Modified: 2014-10-30
 ENV GCC_VERSION 4.9.2
 
 # "download_prerequisites" pulls down a bunch of tarballs and extracts them,

--- a/4.9/Dockerfile
+++ b/4.9/Dockerfile
@@ -15,6 +15,7 @@ RUN set -xe \
 
 # Last Modified: 2014-10-30
 ENV GCC_VERSION 4.9.2
+# Docker EOL: 2016-10-30
 
 # "download_prerequisites" pulls down a bunch of tarballs and extracts them,
 # but then leaves the tarballs themselves lying around

--- a/5.1/Dockerfile
+++ b/5.1/Dockerfile
@@ -13,7 +13,7 @@ RUN set -xe \
 		gpg --keyserver ha.pool.sks-keyservers.net --recv-keys "$key"; \
 	done
 
-# Last Modified: 2015-Apr-22 06:41:29
+# Last Modified: 2015-04-22
 ENV GCC_VERSION 5.1.0
 
 # "download_prerequisites" pulls down a bunch of tarballs and extracts them,

--- a/5.1/Dockerfile
+++ b/5.1/Dockerfile
@@ -15,6 +15,7 @@ RUN set -xe \
 
 # Last Modified: 2015-04-22
 ENV GCC_VERSION 5.1.0
+# Docker EOL: 2017-04-22
 
 # "download_prerequisites" pulls down a bunch of tarballs and extracts them,
 # but then leaves the tarballs themselves lying around

--- a/generate-stackbrew-library.sh
+++ b/generate-stackbrew-library.sh
@@ -20,7 +20,9 @@ for version in "${versions[@]}"; do
 	versionAliases=( $fullVersion $version ${aliases[$version]} )
 	
 	echo
+	grep -m1 '^# Last Modified: ' "$version/Dockerfile"
 	for va in "${versionAliases[@]}"; do
 		echo "$va: ${url}@${commit} $version"
 	done
+	grep -m1 '^# Docker EOL: ' "$version/Dockerfile"
 done

--- a/update.sh
+++ b/update.sh
@@ -10,13 +10,29 @@ fi
 versions=( "${versions[@]%/}" )
 
 #packagesUrl='http://ftpmirror.gnu.org/gcc/'
-packagesUrl='http://mirrors.ibiblio.org/gnu/ftp/gnu/gcc/' # the actual HTML of the page changes based on which mirror we end up hitting, so let's hit a specific one for now... :'(
+packagesUrl='https://mirrors.kernel.org/gnu/gcc/' # the actual HTML of the page changes based on which mirror we end up hitting, so let's hit a specific one for now... :'(
 packages="$(echo "$packagesUrl" | sed -r 's/[^a-zA-Z.-]+/-/g')"
 curl -sSL "$packagesUrl" > "$packages"
 
+# our own "supported" window is 2 years because upstream doesn't have a good guideline, but appears to only release maintenance updates for 2-3 years
+export TZ=UTC
+eolPeriod='2 years'
+today="$(date +'%s')"
+eolAgo="$(date +'%s' -d "$(date -d "@$today") - $eolPeriod")"
+eolAge="$(( $today - $eolAgo ))"
+eols=()
+
+dateFormat='%Y-%m-%d'
+
 for version in "${versions[@]}"; do
 	fullVersion="$(grep '<a href="gcc-'"$version." "$packages" | sed -r 's!.*<a href="gcc-([^"/]+)/?".*!\1!' | sort -V | tail -1)"
-	lastModified="$(grep -m1 '<a href="gcc-'"$fullVersion"'/"' "$packages" | sed -r 's!.*<td class="m">([^<>]+)</td>.*!\1!')"
+	lastModified="$(grep -m1 '<a href="gcc-'"$fullVersion"'/"' "$packages" | awk -F '  +' '{ print $2 }')"
+	lastModified="$(date -d "$lastModified" +"$dateFormat")"
+	
+	releaseAge="$(( $today - $(date +'%s' -d "$lastModified") ))"
+	if [ $releaseAge -gt $eolAge ]; then
+		eols+=( "$version ($fullVersion)" )
+	fi
 	
 	(
 		set -x
@@ -26,5 +42,21 @@ for version in "${versions[@]}"; do
 		' "$version/Dockerfile"
 	)
 done
+
+if [ ${#eols[@]} -gt 0 ]; then
+	{
+		echo
+		echo
+		echo
+		echo " WARNING: the following releases are older than $eolPeriod:"
+		echo
+		for eol in "${eols[@]}"; do
+			echo "   - $eol"
+		done
+		echo
+		echo
+		echo
+	} >&2
+fi
 
 rm "$packages"

--- a/update.sh
+++ b/update.sh
@@ -33,12 +33,14 @@ for version in "${versions[@]}"; do
 	if [ $releaseAge -gt $eolAge ]; then
 		eols+=( "$version ($fullVersion)" )
 	fi
+	eolDate="$(date -d "$lastModified + $eolPeriod" +"$dateFormat")"
 	
 	(
 		set -x
 		sed -ri '
 			s/^(ENV GCC_VERSION) .*/\1 '"$fullVersion"'/;
 			s/^(# Last Modified:) .*/\1 '"$lastModified"'/;
+			s/^(# Docker EOL:) .*/\1 '"$eolDate"'/;
 		' "$version/Dockerfile"
 	)
 done


### PR DESCRIPTION
```console
$ ./update.sh
+ sed -ri '
			s/^(ENV GCC_VERSION) .*/\1 4.6.4/;
			s/^(# Last Modified:) .*/\1 2013-04-12/;
			s/^(# Docker EOL:) .*/\1 2015-04-12/;
		' 4.6/Dockerfile
+ sed -ri '
			s/^(ENV GCC_VERSION) .*/\1 4.7.4/;
			s/^(# Last Modified:) .*/\1 2014-06-12/;
			s/^(# Docker EOL:) .*/\1 2016-06-12/;
		' 4.7/Dockerfile
+ sed -ri '
			s/^(ENV GCC_VERSION) .*/\1 4.8.4/;
			s/^(# Last Modified:) .*/\1 2014-12-19/;
			s/^(# Docker EOL:) .*/\1 2016-12-19/;
		' 4.8/Dockerfile
+ sed -ri '
			s/^(ENV GCC_VERSION) .*/\1 4.9.2/;
			s/^(# Last Modified:) .*/\1 2014-10-30/;
			s/^(# Docker EOL:) .*/\1 2016-10-30/;
		' 4.9/Dockerfile
+ sed -ri '
			s/^(ENV GCC_VERSION) .*/\1 5.1.0/;
			s/^(# Last Modified:) .*/\1 2015-04-22/;
			s/^(# Docker EOL:) .*/\1 2017-04-22/;
		' 5.1/Dockerfile



 WARNING: the following releases are older than 2 years:

   - 4.6 (4.6.4)



```