### PR TITLE
Add '/usr/local/lib64' to 'ld.so.conf' since gcc installs there

### DIFF
--- a/4.7/Dockerfile
+++ b/4.7/Dockerfile
@@ -43,6 +43,10 @@ RUN buildDeps='flex' \
 	&& rm -rf "$dir" \
 	&& apt-get purge -y --auto-remove $buildDeps
 
+# gcc installs .so files in /usr/local/lib64...
+RUN echo '/usr/local/lib64' > /etc/ld.so.conf.d/local-lib64.conf \
+	&& ldconfig -v
+
 # ensure that alternatives are pointing to the new compiler and that old one is no longer used
 RUN set -x \
 	&& dpkg-divert --divert /usr/bin/gcc.orig --rename /usr/bin/gcc \

--- a/4.8/Dockerfile
+++ b/4.8/Dockerfile
@@ -43,6 +43,10 @@ RUN buildDeps='flex' \
 	&& rm -rf "$dir" \
 	&& apt-get purge -y --auto-remove $buildDeps
 
+# gcc installs .so files in /usr/local/lib64...
+RUN echo '/usr/local/lib64' > /etc/ld.so.conf.d/local-lib64.conf \
+	&& ldconfig -v
+
 # ensure that alternatives are pointing to the new compiler and that old one is no longer used
 RUN set -x \
 	&& dpkg-divert --divert /usr/bin/gcc.orig --rename /usr/bin/gcc \

--- a/4.9/Dockerfile
+++ b/4.9/Dockerfile
@@ -43,6 +43,10 @@ RUN buildDeps='flex' \
 	&& rm -rf "$dir" \
 	&& apt-get purge -y --auto-remove $buildDeps
 
+# gcc installs .so files in /usr/local/lib64...
+RUN echo '/usr/local/lib64' > /etc/ld.so.conf.d/local-lib64.conf \
+	&& ldconfig -v
+
 # ensure that alternatives are pointing to the new compiler and that old one is no longer used
 RUN set -x \
 	&& dpkg-divert --divert /usr/bin/gcc.orig --rename /usr/bin/gcc \

--- a/5.1/Dockerfile
+++ b/5.1/Dockerfile
@@ -43,6 +43,10 @@ RUN buildDeps='flex' \
 	&& rm -rf "$dir" \
 	&& apt-get purge -y --auto-remove $buildDeps
 
+# gcc installs .so files in /usr/local/lib64...
+RUN echo '/usr/local/lib64' > /etc/ld.so.conf.d/local-lib64.conf \
+	&& ldconfig -v
+
 # ensure that alternatives are pointing to the new compiler and that old one is no longer used
 RUN set -x \
 	&& dpkg-divert --divert /usr/bin/gcc.orig --rename /usr/bin/gcc \


### PR DESCRIPTION
Fixes #18

cc @thewtex (in case you wanted to give this fix a shot :+1: -- it should be runnable without rebuilding all of `gcc`, which takes forever and a half)