### PR TITLE
Adjust EOL to be one year from the last release

### DIFF
--- a/4.7/Dockerfile
+++ b/4.7/Dockerfile
@@ -15,7 +15,7 @@ RUN set -xe \
 
 # Last Modified: 2014-06-12
 ENV GCC_VERSION 4.7.4
-# Docker EOL: 2016-06-12
+# Docker EOL: 2015-06-12
 
 # "download_prerequisites" pulls down a bunch of tarballs and extracts them,
 # but then leaves the tarballs themselves lying around

--- a/4.8/Dockerfile
+++ b/4.8/Dockerfile
@@ -15,7 +15,7 @@ RUN set -xe \
 
 # Last Modified: 2015-06-23
 ENV GCC_VERSION 4.8.5
-# Docker EOL: 2017-06-23
+# Docker EOL: 2016-06-23
 
 # "download_prerequisites" pulls down a bunch of tarballs and extracts them,
 # but then leaves the tarballs themselves lying around

--- a/4.9/Dockerfile
+++ b/4.9/Dockerfile
@@ -15,7 +15,7 @@ RUN set -xe \
 
 # Last Modified: 2015-06-26
 ENV GCC_VERSION 4.9.3
-# Docker EOL: 2017-06-26
+# Docker EOL: 2016-06-26
 
 # "download_prerequisites" pulls down a bunch of tarballs and extracts them,
 # but then leaves the tarballs themselves lying around

--- a/5.1/Dockerfile
+++ b/5.1/Dockerfile
@@ -15,7 +15,7 @@ RUN set -xe \
 
 # Last Modified: 2015-04-22
 ENV GCC_VERSION 5.1.0
-# Docker EOL: 2017-04-22
+# Docker EOL: 2016-04-22
 
 # "download_prerequisites" pulls down a bunch of tarballs and extracts them,
 # but then leaves the tarballs themselves lying around

--- a/update.sh
+++ b/update.sh
@@ -14,9 +14,10 @@ packagesUrl='https://mirrors.kernel.org/gnu/gcc/' # the actual HTML of the page 
 packages="$(echo "$packagesUrl" | sed -r 's/[^a-zA-Z.-]+/-/g')"
 curl -fsSL "$packagesUrl" > "$packages"
 
-# our own "supported" window is 2 years because upstream doesn't have a good guideline, but appears to only release maintenance updates for 2-3 years
+# our own "supported" window is 1 year from the most recent release because upstream doesn't have a good guideline, but appears to only release maintenance updates for 2-3 years after the initial release
+# in addition, maintenance releases are _usually_ less than a year apart; from 4.7+ there's only one outlier, and it's 4.7.3->4.7.4 at ~14 months
 export TZ=UTC
-eolPeriod='2 years'
+eolPeriod='1 year'
 today="$(date +'%s')"
 eolAgo="$(date +'%s' -d "$(date -d "@$today") - $eolPeriod")"
 eolAge="$(( $today - $eolAgo ))"


### PR DESCRIPTION
Two years was _way_ too permissive.  Two years from the "initial" release would be fine, but from every subsequent is just too much.

Most maintenance releases are one year or less apart, barring the single outlier of 4.7.3 to 4.7.4:

	gcc-4.7.0/	22-Mar-2012 05:36
	gcc-4.7.1/	14-Jun-2012 08:36
	gcc-4.7.2/	20-Sep-2012 10:58
	gcc-4.7.3/	11-Apr-2013 05:41
	gcc-4.7.4/	12-Jun-2014 14:36

	gcc-4.8.0/	22-Mar-2013 15:18
	gcc-4.8.1/	31-May-2013 06:40
	gcc-4.8.2/	16-Oct-2013 05:06
	gcc-4.8.3/	22-May-2014 07:55
	gcc-4.8.4/	19-Dec-2014 08:06
	gcc-4.8.5/	23-Jun-2015 11:36

	gcc-4.9.0/	22-Apr-2014 07:16
	gcc-4.9.1/	16-Jul-2014 09:16
	gcc-4.9.2/	30-Oct-2014 06:01
	gcc-4.9.3/	26-Jun-2015 16:30

	gcc-5.1.0/	22-Apr-2015 06:41

	gcc-5.2.0/	16-Jul-2015 08:21

(This does also mean that 4.7 is EOL, so if this merges, I'll be removing it from the official build rotation promptly.)