### PR TITLE
Please upgrade to jessie to make docker builds work

### DIFF
--- a/5.2/Dockerfile
+++ b/5.2/Dockerfile
@@ -1,4 +1,4 @@
-FROM buildpack-deps:wheezy
+FROM buildpack-deps:jessie
 
 # https://gcc.gnu.org/mirrors.html
 ENV GPG_KEYS \


### PR DESCRIPTION
Signed-off-by: Srini Brahmaroutu <srbrahma@us.ibm.com>

Please use debian:jessie as Docker builds have issues as many components are not installed correctly.
For example 
docker run -ti buildpack-deps:wheezy sh -c "apt-get update && apt-get install -y btrfs-tools && ls /usr/include/btrfs" shows only one file 
docker run -ti buildpack-deps:jessie sh -c "apt-get update && apt-get install -y btrfs-tools && ls /usr/include/btrfs" shows that all header files are present, that are required by dockers' graph driver. 
We are also seeing other issues when running docker tests using wheezy as base image. 
