### PR TITLE
updates gcc 6.1 to include Fortran support

### DIFF
--- a/5.2/Dockerfile
+++ b/5.2/Dockerfile
@@ -36,7 +36,7 @@ RUN buildDeps='flex' \
 	&& cd "$dir" \
 	&& /usr/src/gcc/configure \
 		--disable-multilib \
-		--enable-languages=c,c++,go \
+		--enable-languages=c,c++,fortran,go \
 	&& make -j"$(nproc)" \
 	&& make install-strip \
 	&& cd .. \
@@ -51,4 +51,5 @@ RUN echo '/usr/local/lib64' > /etc/ld.so.conf.d/local-lib64.conf \
 RUN set -x \
 	&& dpkg-divert --divert /usr/bin/gcc.orig --rename /usr/bin/gcc \
 	&& dpkg-divert --divert /usr/bin/g++.orig --rename /usr/bin/g++ \
+	&& dpkg-divert --divert /usr/bin/gfortran.orig --rename /usr/bin/gfortran \
 	&& update-alternatives --install /usr/bin/cc cc /usr/local/bin/gcc 999

--- a/5.3/Dockerfile
+++ b/5.3/Dockerfile
@@ -36,7 +36,7 @@ RUN buildDeps='flex' \
 	&& cd "$dir" \
 	&& /usr/src/gcc/configure \
 		--disable-multilib \
-		--enable-languages=c,c++,go \
+		--enable-languages=c,c++,fortran,go \
 	&& make -j"$(nproc)" \
 	&& make install-strip \
 	&& cd .. \
@@ -51,4 +51,5 @@ RUN echo '/usr/local/lib64' > /etc/ld.so.conf.d/local-lib64.conf \
 RUN set -x \
 	&& dpkg-divert --divert /usr/bin/gcc.orig --rename /usr/bin/gcc \
 	&& dpkg-divert --divert /usr/bin/g++.orig --rename /usr/bin/g++ \
+	&& dpkg-divert --divert /usr/bin/gfortran.orig --rename /usr/bin/gfortran \
 	&& update-alternatives --install /usr/bin/cc cc /usr/local/bin/gcc 999

--- a/6.1/Dockerfile
+++ b/6.1/Dockerfile
@@ -36,7 +36,7 @@ RUN buildDeps='flex' \
 	&& cd "$dir" \
 	&& /usr/src/gcc/configure \
 		--disable-multilib \
-		--enable-languages=c,c++,go \
+		--enable-languages=c,c++,fortran,go \
 	&& make -j"$(nproc)" \
 	&& make install-strip \
 	&& cd .. \
@@ -51,4 +51,5 @@ RUN echo '/usr/local/lib64' > /etc/ld.so.conf.d/local-lib64.conf \
 RUN set -x \
 	&& dpkg-divert --divert /usr/bin/gcc.orig --rename /usr/bin/gcc \
 	&& dpkg-divert --divert /usr/bin/g++.orig --rename /usr/bin/g++ \
+	&& dpkg-divert --divert /usr/bin/gfortran.orig --rename /usr/bin/gfortran \
 	&& update-alternatives --install /usr/bin/cc cc /usr/local/bin/gcc 999


### PR DESCRIPTION
Hi! Because **golang** isn't a default language when building gcc, it's unclear to me whether **Fortran** support was intentionally disabled for Docker's official image for gcc. Hoping it was just an oversight so that I and others in the scientific computing community can build on top of your work!