### PR TITLE
Refactor to mirror upstream "support tracks" (and add the still-upstream-supported 4.9 series back)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,9 @@ language: bash
 services: docker
 
 env:
-  - VERSION=6.1
-  - VERSION=5.3
+  - VERSION=6
+  - VERSION=5
+  - VERSION=4.9
 
 install:
   - git clone https://github.com/docker-library/official-images.git ~/official-images

--- a/4.9/Dockerfile
+++ b/4.9/Dockerfile
@@ -13,9 +13,9 @@ RUN set -xe \
 		gpg --keyserver ha.pool.sks-keyservers.net --recv-keys "$key"; \
 	done
 
-# Last Modified: 2015-12-04
-ENV GCC_VERSION 5.3.0
-# Docker EOL: 2016-12-04
+# Last Modified: 2016-08-03
+ENV GCC_VERSION 4.9.4
+# Docker EOL: 2017-08-03
 
 # "download_prerequisites" pulls down a bunch of tarballs and extracts them,
 # but then leaves the tarballs themselves lying around

--- a/5/Dockerfile
+++ b/5/Dockerfile
@@ -1,0 +1,55 @@
+FROM buildpack-deps:jessie
+
+# https://gcc.gnu.org/mirrors.html
+ENV GPG_KEYS \
+	B215C1633BCA0477615F1B35A5B3A004745C015A \
+	B3C42148A44E6983B3E4CC0793FA9B1AB75C61B8 \
+	90AA470469D3965A87A5DCB494D03953902C9419 \
+	80F98B2E0DAB6C8281BDF541A7C8C3B2F71EDF1C \
+	7F74F97C103468EE5D750B583AB00996FC26A641 \
+	33C235A34C46AA3FFB293709A328C3A2C3C45C06
+RUN set -xe \
+	&& for key in $GPG_KEYS; do \
+		gpg --keyserver ha.pool.sks-keyservers.net --recv-keys "$key"; \
+	done
+
+# Last Modified: 2016-06-03
+ENV GCC_VERSION 5.4.0
+# Docker EOL: 2017-06-03
+
+# "download_prerequisites" pulls down a bunch of tarballs and extracts them,
+# but then leaves the tarballs themselves lying around
+RUN buildDeps='flex' \
+	&& set -x \
+	&& apt-get update && apt-get install -y $buildDeps --no-install-recommends \
+	&& rm -r /var/lib/apt/lists/* \
+	&& curl -fSL "http://ftpmirror.gnu.org/gcc/gcc-$GCC_VERSION/gcc-$GCC_VERSION.tar.bz2" -o gcc.tar.bz2 \
+	&& curl -fSL "http://ftpmirror.gnu.org/gcc/gcc-$GCC_VERSION/gcc-$GCC_VERSION.tar.bz2.sig" -o gcc.tar.bz2.sig \
+	&& gpg --batch --verify gcc.tar.bz2.sig gcc.tar.bz2 \
+	&& mkdir -p /usr/src/gcc \
+	&& tar -xf gcc.tar.bz2 -C /usr/src/gcc --strip-components=1 \
+	&& rm gcc.tar.bz2* \
+	&& cd /usr/src/gcc \
+	&& ./contrib/download_prerequisites \
+	&& { rm *.tar.* || true; } \
+	&& dir="$(mktemp -d)" \
+	&& cd "$dir" \
+	&& /usr/src/gcc/configure \
+		--disable-multilib \
+		--enable-languages=c,c++,fortran,go \
+	&& make -j"$(nproc)" \
+	&& make install-strip \
+	&& cd .. \
+	&& rm -rf "$dir" \
+	&& apt-get purge -y --auto-remove $buildDeps
+
+# gcc installs .so files in /usr/local/lib64...
+RUN echo '/usr/local/lib64' > /etc/ld.so.conf.d/local-lib64.conf \
+	&& ldconfig -v
+
+# ensure that alternatives are pointing to the new compiler and that old one is no longer used
+RUN set -x \
+	&& dpkg-divert --divert /usr/bin/gcc.orig --rename /usr/bin/gcc \
+	&& dpkg-divert --divert /usr/bin/g++.orig --rename /usr/bin/g++ \
+	&& dpkg-divert --divert /usr/bin/gfortran.orig --rename /usr/bin/gfortran \
+	&& update-alternatives --install /usr/bin/cc cc /usr/local/bin/gcc 999

--- a/6/Dockerfile
+++ b/6/Dockerfile
@@ -13,9 +13,9 @@ RUN set -xe \
 		gpg --keyserver ha.pool.sks-keyservers.net --recv-keys "$key"; \
 	done
 
-# Last Modified: 2016-04-27
-ENV GCC_VERSION 6.1.0
-# Docker EOL: 2017-04-27
+# Last Modified: 2016-08-22
+ENV GCC_VERSION 6.2.0
+# Docker EOL: 2017-08-22
 
 # "download_prerequisites" pulls down a bunch of tarballs and extracts them,
 # but then leaves the tarballs themselves lying around

--- a/generate-stackbrew-library.sh
+++ b/generate-stackbrew-library.sh
@@ -3,8 +3,7 @@ set -e
 
 declare -A aliases=(
 	[4.9]='4'
-	[5.3]='5'
-	[6.1]='6 latest'
+	[6]='latest'
 )
 
 self="$(basename "$BASH_SOURCE")"
@@ -56,12 +55,16 @@ for version in "${versions[@]}"; do
 	dockerfile="$(git show "$commit":"$version/Dockerfile")"
 	fullVersion="$(echo "$dockerfile" | awk '$1 == "ENV" && $2 == "GCC_VERSION" { print $3; exit }')"
 
-	versionAliases=(
-		$fullVersion
+	versionAliases=()
+	while [ "$fullVersion" != "$version" -a "${fullVersion%[.-]*}" != "$fullVersion" ]; do
+		versionAliases+=( $fullVersion )
+		fullVersion="${fullVersion%[.-]*}"
+	done
+	versionAliases+=(
 		$version
 		${aliases[$version]:-}
 	)
-	
+
 	echo
 	echo "$dockerfile" | grep -m1 '^# Last Modified: '
 	cat <<-EOE


### PR DESCRIPTION
From https://gcc.gnu.org/:

> **News**
>
> - GCC 6.2 released [2016-08-22]
> - GCC 4.9.4 released [2016-08-03]
> - GCC 5.4 released [2016-06-03]
> - GCC 6.1 released [2016-04-27]
> - GCC 5.3 released [2015-12-04]
> - GCC 5.2 released [2015-07-16]
> - GCC 4.9.3 released [2015-06-26]
> - GCC 4.8.5 released [2015-06-23]
> - GCC 5.1 released [2015-04-22]

Note that the 5 and 6 series only get a minor bump, no patch bumps.