### PR TITLE
Add explicit "--build" to our "./configure" invocations

### DIFF
--- a/4.9/Dockerfile
+++ b/4.9/Dockerfile
@@ -17,11 +17,13 @@ RUN set -xe \
 ENV GCC_VERSION 4.9.4
 # Docker EOL: 2017-08-03
 
-# "download_prerequisites" pulls down a bunch of tarballs and extracts them,
-# but then leaves the tarballs themselves lying around
-RUN buildDeps='flex' \
-	&& set -x \
-	&& apt-get update && apt-get install -y $buildDeps --no-install-recommends \
+RUN set -ex \
+	&& buildDeps=' \
+		dpkg-dev \
+		flex \
+	' \
+	&& apt-get update \
+	&& apt-get install -y --no-install-recommends $buildDeps \
 	&& rm -r /var/lib/apt/lists/* \
 	&& curl -fSL "http://ftpmirror.gnu.org/gcc/gcc-$GCC_VERSION/gcc-$GCC_VERSION.tar.bz2" -o gcc.tar.bz2 \
 	&& curl -fSL "http://ftpmirror.gnu.org/gcc/gcc-$GCC_VERSION/gcc-$GCC_VERSION.tar.bz2.sig" -o gcc.tar.bz2.sig \
@@ -30,11 +32,18 @@ RUN buildDeps='flex' \
 	&& tar -xf gcc.tar.bz2 -C /usr/src/gcc --strip-components=1 \
 	&& rm gcc.tar.bz2* \
 	&& cd /usr/src/gcc \
+# "download_prerequisites" pulls down a bunch of tarballs and extracts them,
+# but then leaves the tarballs themselves lying around
 	&& ./contrib/download_prerequisites \
 	&& { rm *.tar.* || true; } \
+# explicitly update autoconf config.guess and config.sub so they support more arches/libcs
+	&& wget -O config.guess "http://git.savannah.gnu.org/gitweb/?p=config.git;a=blob_plain;f=config.guess;hb=HEAD" \
+	&& wget -O config.sub "http://git.savannah.gnu.org/gitweb/?p=config.git;a=blob_plain;f=config.sub;hb=HEAD" \
 	&& dir="$(mktemp -d)" \
 	&& cd "$dir" \
+	&& gnuArch="$(dpkg-architecture --query DEB_BUILD_GNU_TYPE)" \
 	&& /usr/src/gcc/configure \
+		--build="$gnuArch" \
 		--disable-multilib \
 		--enable-languages=c,c++,fortran,go \
 	&& make -j"$(nproc)" \

--- a/5/Dockerfile
+++ b/5/Dockerfile
@@ -17,11 +17,13 @@ RUN set -xe \
 ENV GCC_VERSION 5.4.0
 # Docker EOL: 2017-06-03
 
-# "download_prerequisites" pulls down a bunch of tarballs and extracts them,
-# but then leaves the tarballs themselves lying around
-RUN buildDeps='flex' \
-	&& set -x \
-	&& apt-get update && apt-get install -y $buildDeps --no-install-recommends \
+RUN set -ex \
+	&& buildDeps=' \
+		dpkg-dev \
+		flex \
+	' \
+	&& apt-get update \
+	&& apt-get install -y --no-install-recommends $buildDeps \
 	&& rm -r /var/lib/apt/lists/* \
 	&& curl -fSL "http://ftpmirror.gnu.org/gcc/gcc-$GCC_VERSION/gcc-$GCC_VERSION.tar.bz2" -o gcc.tar.bz2 \
 	&& curl -fSL "http://ftpmirror.gnu.org/gcc/gcc-$GCC_VERSION/gcc-$GCC_VERSION.tar.bz2.sig" -o gcc.tar.bz2.sig \
@@ -30,11 +32,18 @@ RUN buildDeps='flex' \
 	&& tar -xf gcc.tar.bz2 -C /usr/src/gcc --strip-components=1 \
 	&& rm gcc.tar.bz2* \
 	&& cd /usr/src/gcc \
+# "download_prerequisites" pulls down a bunch of tarballs and extracts them,
+# but then leaves the tarballs themselves lying around
 	&& ./contrib/download_prerequisites \
 	&& { rm *.tar.* || true; } \
+# explicitly update autoconf config.guess and config.sub so they support more arches/libcs
+	&& wget -O config.guess "http://git.savannah.gnu.org/gitweb/?p=config.git;a=blob_plain;f=config.guess;hb=HEAD" \
+	&& wget -O config.sub "http://git.savannah.gnu.org/gitweb/?p=config.git;a=blob_plain;f=config.sub;hb=HEAD" \
 	&& dir="$(mktemp -d)" \
 	&& cd "$dir" \
+	&& gnuArch="$(dpkg-architecture --query DEB_BUILD_GNU_TYPE)" \
 	&& /usr/src/gcc/configure \
+		--build="$gnuArch" \
 		--disable-multilib \
 		--enable-languages=c,c++,fortran,go \
 	&& make -j"$(nproc)" \

--- a/6/Dockerfile
+++ b/6/Dockerfile
@@ -17,11 +17,13 @@ RUN set -xe \
 ENV GCC_VERSION 6.3.0
 # Docker EOL: 2017-12-21
 
-# "download_prerequisites" pulls down a bunch of tarballs and extracts them,
-# but then leaves the tarballs themselves lying around
-RUN buildDeps='flex' \
-	&& set -x \
-	&& apt-get update && apt-get install -y $buildDeps --no-install-recommends \
+RUN set -ex \
+	&& buildDeps=' \
+		dpkg-dev \
+		flex \
+	' \
+	&& apt-get update \
+	&& apt-get install -y --no-install-recommends $buildDeps \
 	&& rm -r /var/lib/apt/lists/* \
 	&& curl -fSL "http://ftpmirror.gnu.org/gcc/gcc-$GCC_VERSION/gcc-$GCC_VERSION.tar.bz2" -o gcc.tar.bz2 \
 	&& curl -fSL "http://ftpmirror.gnu.org/gcc/gcc-$GCC_VERSION/gcc-$GCC_VERSION.tar.bz2.sig" -o gcc.tar.bz2.sig \
@@ -30,11 +32,18 @@ RUN buildDeps='flex' \
 	&& tar -xf gcc.tar.bz2 -C /usr/src/gcc --strip-components=1 \
 	&& rm gcc.tar.bz2* \
 	&& cd /usr/src/gcc \
+# "download_prerequisites" pulls down a bunch of tarballs and extracts them,
+# but then leaves the tarballs themselves lying around
 	&& ./contrib/download_prerequisites \
 	&& { rm *.tar.* || true; } \
+# explicitly update autoconf config.guess and config.sub so they support more arches/libcs
+	&& wget -O config.guess "http://git.savannah.gnu.org/gitweb/?p=config.git;a=blob_plain;f=config.guess;hb=HEAD" \
+	&& wget -O config.sub "http://git.savannah.gnu.org/gitweb/?p=config.git;a=blob_plain;f=config.sub;hb=HEAD" \
 	&& dir="$(mktemp -d)" \
 	&& cd "$dir" \
+	&& gnuArch="$(dpkg-architecture --query DEB_BUILD_GNU_TYPE)" \
 	&& /usr/src/gcc/configure \
+		--build="$gnuArch" \
 		--disable-multilib \
 		--enable-languages=c,c++,fortran,go \
 	&& make -j"$(nproc)" \

--- a/7/Dockerfile
+++ b/7/Dockerfile
@@ -25,11 +25,13 @@ RUN set -ex; \
 ENV GCC_VERSION 7.1.0
 # Docker EOL: 2018-05-02
 
-# "download_prerequisites" pulls down a bunch of tarballs and extracts them,
-# but then leaves the tarballs themselves lying around
-RUN buildDeps='flex' \
-	&& set -x \
-	&& apt-get update && apt-get install -y $buildDeps --no-install-recommends \
+RUN set -ex \
+	&& buildDeps=' \
+		dpkg-dev \
+		flex \
+	' \
+	&& apt-get update \
+	&& apt-get install -y --no-install-recommends $buildDeps \
 	&& rm -r /var/lib/apt/lists/* \
 	&& curl -fSL "http://ftpmirror.gnu.org/gcc/gcc-$GCC_VERSION/gcc-$GCC_VERSION.tar.bz2" -o gcc.tar.bz2 \
 	&& curl -fSL "http://ftpmirror.gnu.org/gcc/gcc-$GCC_VERSION/gcc-$GCC_VERSION.tar.bz2.sig" -o gcc.tar.bz2.sig \
@@ -38,11 +40,18 @@ RUN buildDeps='flex' \
 	&& tar -xf gcc.tar.bz2 -C /usr/src/gcc --strip-components=1 \
 	&& rm gcc.tar.bz2* \
 	&& cd /usr/src/gcc \
+# "download_prerequisites" pulls down a bunch of tarballs and extracts them,
+# but then leaves the tarballs themselves lying around
 	&& ./contrib/download_prerequisites \
 	&& { rm *.tar.* || true; } \
+# explicitly update autoconf config.guess and config.sub so they support more arches/libcs
+	&& wget -O config.guess "http://git.savannah.gnu.org/gitweb/?p=config.git;a=blob_plain;f=config.guess;hb=HEAD" \
+	&& wget -O config.sub "http://git.savannah.gnu.org/gitweb/?p=config.git;a=blob_plain;f=config.sub;hb=HEAD" \
 	&& dir="$(mktemp -d)" \
 	&& cd "$dir" \
+	&& gnuArch="$(dpkg-architecture --query DEB_BUILD_GNU_TYPE)" \
 	&& /usr/src/gcc/configure \
+		--build="$gnuArch" \
 		--disable-multilib \
 		--enable-languages=c,c++,fortran,go \
 	&& make -j"$(nproc)" \


### PR DESCRIPTION
This is along the same lines as:

- https://github.com/docker-library/httpd/pull/51
- https://github.com/jessfraz/irssi/pull/14
- https://github.com/docker-library/php/pull/429
- https://github.com/docker-library/postgres/pull/284
- https://github.com/docker-library/python/pull/198
- https://github.com/docker-library/ruby/pull/127
- https://github.com/docker-library/tomcat/pull/70
- https://github.com/tianon/docker-bash/pull/3
- https://github.com/docker-library/memcached/pull/13