### PR TITLE
Add function to get architectures of parent images so each gcc image has the same set

### DIFF
--- a/generate-stackbrew-library.sh
+++ b/generate-stackbrew-library.sh
@@ -34,6 +34,22 @@ dirCommit() {
 	)
 }
 
+getArches() {
+	local repo="$1"; shift
+	local officialImagesUrl='https://github.com/docker-library/official-images/raw/master/library/'
+
+	eval "declare -A -g parentRepoToArches=( $(
+		find -name 'Dockerfile' -exec awk '
+				toupper($1) == "FROM" && $2 !~ /^('"$repo"'|scratch|microsoft\/[^:]+)(:|$)/ {
+					print "'"$officialImagesUrl"'" $2
+				}
+			' '{}' + \
+			| sort -u \
+			| xargs bashbrew cat --format '[{{ .RepoName }}:{{ .TagName }}]="{{ join " " .TagEntry.Architectures }}"'
+	) )"
+}
+getArches 'gcc'
+
 cat <<-EOH
 # this file is generated via https://github.com/docker-library/gcc/blob/$(fileCommit "$self")/$self
 
@@ -51,6 +67,8 @@ join() {
 
 for version in "${versions[@]}"; do
 	commit="$(dirCommit "$version")"
+	parent="$(awk 'toupper($1) == "FROM" { print $2 }' "$version/Dockerfile")"
+	arches="${parentRepoToArches[$parent]}"
 
 	dockerfile="$(git show "$commit":"$version/Dockerfile")"
 	fullVersion="$(echo "$dockerfile" | awk '$1 == "ENV" && $2 == "GCC_VERSION" { print $3; exit }')"
@@ -69,6 +87,7 @@ for version in "${versions[@]}"; do
 	echo "$dockerfile" | grep -m1 '^# Last Modified: '
 	cat <<-EOE
 		Tags: $(join ', ' "${versionAliases[@]}")
+		Architectures: $(join ', ' $arches)
 		GitCommit: $commit
 		Directory: $version
 	EOE

--- a/generate-stackbrew-library.sh
+++ b/generate-stackbrew-library.sh
@@ -68,7 +68,8 @@ join() {
 for version in "${versions[@]}"; do
 	commit="$(dirCommit "$version")"
 	parent="$(awk 'toupper($1) == "FROM" { print $2 }' "$version/Dockerfile")"
-	arches="${parentRepoToArches[$parent]}"
+	# no arm32 for now: https://github.com/docker-library/gcc/issues/37
+	arches="$(echo " ${parentRepoToArches[$parent]} " | sed -r 's/ arm32v[^ ]+ / /g')"
 
 	dockerfile="$(git show "$commit":"$version/Dockerfile")"
 	fullVersion="$(echo "$dockerfile" | awk '$1 == "ENV" && $2 == "GCC_VERSION" { print $3; exit }')"


### PR DESCRIPTION
No hurry. :wink:
```
$ # master branch
$ ./generate-stackbrew-library.sh > gcc-old
$ # archy branch
$ ./generate-stackbrew-library.sh > gcc-new
$ diff gcc-old gcc-new
1c1
< # this file is generated via https://github.com/docker-library/gcc/blob/87dfadb46c2a905abb1bcd383ec15028e4454435/generate-stackbrew-library.sh
---
> # this file is generated via https://github.com/docker-library/gcc/blob/f71e9f9cec20b66bfbab98fd1dc8df78f86647c8/generate-stackbrew-library.sh
8a9
> Architectures: amd64
14a16
> Architectures: amd64
20a23
> Architectures: amd64
26a30
> Architectures: amd64
```