### PR TITLE
Add back arm32v5 and arm32v7

### DIFF
--- a/4.9/Dockerfile
+++ b/4.9/Dockerfile
@@ -75,12 +75,9 @@ RUN set -ex; \
 # with-mode: https://anonscm.debian.org/viewvc/gcccvs/branches/sid/gcc-6/debian/rules.defs?revision=9487&view=markup#l376
 		armel) \
 			extraConfigureArgs="$extraConfigureArgs --with-arch=armv4t --with-float=soft" \
-# TODO get enough builders to test and verify arm32v5 O:)
 			;; \
 		armhf) \
 			extraConfigureArgs="$extraConfigureArgs --with-arch=armv7-a --with-float=hard --with-fpu=vfpv3-d16 --with-mode=thumb" \
-# TODO make[2]: *** No rule to make target '/usr/src/gcc/gcc/sync-builtinsndef', needed by 'tree-ssa-loop-prefetch.o'.  Stop.
-# (which the builds takes _forever_ to get to)
 			;; \
 		\
 # with-arch-32: https://anonscm.debian.org/viewvc/gcccvs/branches/sid/gcc-6/debian/rules2?revision=9450&view=markup#l590

--- a/5/Dockerfile
+++ b/5/Dockerfile
@@ -75,12 +75,9 @@ RUN set -ex; \
 # with-mode: https://anonscm.debian.org/viewvc/gcccvs/branches/sid/gcc-6/debian/rules.defs?revision=9487&view=markup#l376
 		armel) \
 			extraConfigureArgs="$extraConfigureArgs --with-arch=armv4t --with-float=soft" \
-# TODO get enough builders to test and verify arm32v5 O:)
 			;; \
 		armhf) \
 			extraConfigureArgs="$extraConfigureArgs --with-arch=armv7-a --with-float=hard --with-fpu=vfpv3-d16 --with-mode=thumb" \
-# TODO make[2]: *** No rule to make target '/usr/src/gcc/gcc/sync-builtinsndef', needed by 'tree-ssa-loop-prefetch.o'.  Stop.
-# (which the builds takes _forever_ to get to)
 			;; \
 		\
 # with-arch-32: https://anonscm.debian.org/viewvc/gcccvs/branches/sid/gcc-6/debian/rules2?revision=9450&view=markup#l590

--- a/6/Dockerfile
+++ b/6/Dockerfile
@@ -75,12 +75,9 @@ RUN set -ex; \
 # with-mode: https://anonscm.debian.org/viewvc/gcccvs/branches/sid/gcc-6/debian/rules.defs?revision=9487&view=markup#l376
 		armel) \
 			extraConfigureArgs="$extraConfigureArgs --with-arch=armv4t --with-float=soft" \
-# TODO get enough builders to test and verify arm32v5 O:)
 			;; \
 		armhf) \
 			extraConfigureArgs="$extraConfigureArgs --with-arch=armv7-a --with-float=hard --with-fpu=vfpv3-d16 --with-mode=thumb" \
-# TODO make[2]: *** No rule to make target '/usr/src/gcc/gcc/sync-builtinsndef', needed by 'tree-ssa-loop-prefetch.o'.  Stop.
-# (which the builds takes _forever_ to get to)
 			;; \
 		\
 # with-arch-32: https://anonscm.debian.org/viewvc/gcccvs/branches/sid/gcc-6/debian/rules2?revision=9450&view=markup#l590

--- a/7/Dockerfile
+++ b/7/Dockerfile
@@ -75,12 +75,9 @@ RUN set -ex; \
 # with-mode: https://anonscm.debian.org/viewvc/gcccvs/branches/sid/gcc-6/debian/rules.defs?revision=9487&view=markup#l376
 		armel) \
 			extraConfigureArgs="$extraConfigureArgs --with-arch=armv4t --with-float=soft" \
-# TODO get enough builders to test and verify arm32v5 O:)
 			;; \
 		armhf) \
 			extraConfigureArgs="$extraConfigureArgs --with-arch=armv7-a --with-float=hard --with-fpu=vfpv3-d16 --with-mode=thumb" \
-# TODO make[2]: *** No rule to make target '/usr/src/gcc/gcc/sync-builtinsndef', needed by 'tree-ssa-loop-prefetch.o'.  Stop.
-# (which the builds takes _forever_ to get to)
 			;; \
 		\
 # with-arch-32: https://anonscm.debian.org/viewvc/gcccvs/branches/sid/gcc-6/debian/rules2?revision=9450&view=markup#l590

--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -75,12 +75,9 @@ RUN set -ex; \
 # with-mode: https://anonscm.debian.org/viewvc/gcccvs/branches/sid/gcc-6/debian/rules.defs?revision=9487&view=markup#l376
 		armel) \
 			extraConfigureArgs="$extraConfigureArgs --with-arch=armv4t --with-float=soft" \
-# TODO get enough builders to test and verify arm32v5 O:)
 			;; \
 		armhf) \
 			extraConfigureArgs="$extraConfigureArgs --with-arch=armv7-a --with-float=hard --with-fpu=vfpv3-d16 --with-mode=thumb" \
-# TODO make[2]: *** No rule to make target '/usr/src/gcc/gcc/sync-builtinsndef', needed by 'tree-ssa-loop-prefetch.o'.  Stop.
-# (which the builds takes _forever_ to get to)
 			;; \
 		\
 # with-arch-32: https://anonscm.debian.org/viewvc/gcccvs/branches/sid/gcc-6/debian/rules2?revision=9450&view=markup#l590

--- a/generate-stackbrew-library.sh
+++ b/generate-stackbrew-library.sh
@@ -68,9 +68,8 @@ join() {
 for version in "${versions[@]}"; do
 	commit="$(dirCommit "$version")"
 	parent="$(awk 'toupper($1) == "FROM" { print $2 }' "$version/Dockerfile")"
-	# no arm32 for now: https://github.com/docker-library/gcc/issues/37
 	# no i386 for now: https://github.com/docker-library/gcc/issues/38
-	arches="$(echo " ${parentRepoToArches[$parent]} " | sed -r -e 's/ (arm32v[^ ]+|i386)//g')"
+	arches="$(echo " ${parentRepoToArches[$parent]} " | sed -r -e 's/ i386//g')"
 
 	dockerfile="$(git show "$commit":"$version/Dockerfile")"
 	fullVersion="$(echo "$dockerfile" | awk '$1 == "ENV" && $2 == "GCC_VERSION" { print $3; exit }')"


### PR DESCRIPTION
I did some compilation tests on our new hardware, and was able to build `arm32v7/gcc:4.9`, `arm32v7/gcc:5`, `arm32v7/gcc:6`, and `arm32v5/gcc:7` _simultaneously_ in ~40 minutes (maxing out all 64 cores many times throughout the build).

Fixes #37