### PR TITLE
Update to 6.5.0

### DIFF
--- a/5/Dockerfile
+++ b/5/Dockerfile
@@ -63,8 +63,11 @@ RUN set -ex; \
 		return 1; \
 	}; \
 	\
-	_fetch "gcc-$GCC_VERSION/gcc-$GCC_VERSION.tar.xz.sig" 'gcc.tar.xz.sig'; \
-	_fetch "gcc-$GCC_VERSION/gcc-$GCC_VERSION.tar.xz" 'gcc.tar.xz'; \
+	_fetch "gcc-$GCC_VERSION/gcc-$GCC_VERSION.tar.xz.sig" 'gcc.tar.xz.sig' \
+# 6.5.0 (https://mirrors.kernel.org/gnu/gcc/6.5.0/), no gcc- prefix
+		|| _fetch "$GCC_VERSION/gcc-$GCC_VERSION.tar.xz.sig"; \
+	_fetch "gcc-$GCC_VERSION/gcc-$GCC_VERSION.tar.xz" 'gcc.tar.xz' \
+		|| _fetch "$GCC_VERSION/gcc-$GCC_VERSION.tar.xz" 'gcc.tar.xz'; \
 	gpg --batch --verify gcc.tar.xz.sig gcc.tar.xz; \
 	mkdir -p /usr/src/gcc; \
 	tar -xf gcc.tar.xz -C /usr/src/gcc --strip-components=1; \

--- a/6/Dockerfile
+++ b/6/Dockerfile
@@ -37,9 +37,9 @@ ENV GCC_MIRRORS \
 		https://mirrors.concertpass.com/gcc/releases \
 		http://www.netgull.com/gcc/releases
 
-# Last Modified: 2017-07-04
-ENV GCC_VERSION 6.4.0
-# Docker EOL: 2018-07-04
+# Last Modified: 2018-10-26
+ENV GCC_VERSION 6.5.0
+# Docker EOL: 2019-10-26
 
 RUN set -ex; \
 	\
@@ -63,8 +63,11 @@ RUN set -ex; \
 		return 1; \
 	}; \
 	\
-	_fetch "gcc-$GCC_VERSION/gcc-$GCC_VERSION.tar.xz.sig" 'gcc.tar.xz.sig'; \
-	_fetch "gcc-$GCC_VERSION/gcc-$GCC_VERSION.tar.xz" 'gcc.tar.xz'; \
+	_fetch "gcc-$GCC_VERSION/gcc-$GCC_VERSION.tar.xz.sig" 'gcc.tar.xz.sig' \
+# 6.5.0 (https://mirrors.kernel.org/gnu/gcc/6.5.0/), no gcc- prefix
+		|| _fetch "$GCC_VERSION/gcc-$GCC_VERSION.tar.xz.sig"; \
+	_fetch "gcc-$GCC_VERSION/gcc-$GCC_VERSION.tar.xz" 'gcc.tar.xz' \
+		|| _fetch "$GCC_VERSION/gcc-$GCC_VERSION.tar.xz" 'gcc.tar.xz'; \
 	gpg --batch --verify gcc.tar.xz.sig gcc.tar.xz; \
 	mkdir -p /usr/src/gcc; \
 	tar -xf gcc.tar.xz -C /usr/src/gcc --strip-components=1; \

--- a/7/Dockerfile
+++ b/7/Dockerfile
@@ -63,8 +63,11 @@ RUN set -ex; \
 		return 1; \
 	}; \
 	\
-	_fetch "gcc-$GCC_VERSION/gcc-$GCC_VERSION.tar.xz.sig" 'gcc.tar.xz.sig'; \
-	_fetch "gcc-$GCC_VERSION/gcc-$GCC_VERSION.tar.xz" 'gcc.tar.xz'; \
+	_fetch "gcc-$GCC_VERSION/gcc-$GCC_VERSION.tar.xz.sig" 'gcc.tar.xz.sig' \
+# 6.5.0 (https://mirrors.kernel.org/gnu/gcc/6.5.0/), no gcc- prefix
+		|| _fetch "$GCC_VERSION/gcc-$GCC_VERSION.tar.xz.sig"; \
+	_fetch "gcc-$GCC_VERSION/gcc-$GCC_VERSION.tar.xz" 'gcc.tar.xz' \
+		|| _fetch "$GCC_VERSION/gcc-$GCC_VERSION.tar.xz" 'gcc.tar.xz'; \
 	gpg --batch --verify gcc.tar.xz.sig gcc.tar.xz; \
 	mkdir -p /usr/src/gcc; \
 	tar -xf gcc.tar.xz -C /usr/src/gcc --strip-components=1; \

--- a/8/Dockerfile
+++ b/8/Dockerfile
@@ -63,8 +63,11 @@ RUN set -ex; \
 		return 1; \
 	}; \
 	\
-	_fetch "gcc-$GCC_VERSION/gcc-$GCC_VERSION.tar.xz.sig" 'gcc.tar.xz.sig'; \
-	_fetch "gcc-$GCC_VERSION/gcc-$GCC_VERSION.tar.xz" 'gcc.tar.xz'; \
+	_fetch "gcc-$GCC_VERSION/gcc-$GCC_VERSION.tar.xz.sig" 'gcc.tar.xz.sig' \
+# 6.5.0 (https://mirrors.kernel.org/gnu/gcc/6.5.0/), no gcc- prefix
+		|| _fetch "$GCC_VERSION/gcc-$GCC_VERSION.tar.xz.sig"; \
+	_fetch "gcc-$GCC_VERSION/gcc-$GCC_VERSION.tar.xz" 'gcc.tar.xz' \
+		|| _fetch "$GCC_VERSION/gcc-$GCC_VERSION.tar.xz" 'gcc.tar.xz'; \
 	gpg --batch --verify gcc.tar.xz.sig gcc.tar.xz; \
 	mkdir -p /usr/src/gcc; \
 	tar -xf gcc.tar.xz -C /usr/src/gcc --strip-components=1; \

--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -63,8 +63,11 @@ RUN set -ex; \
 		return 1; \
 	}; \
 	\
-	_fetch "gcc-$GCC_VERSION/gcc-$GCC_VERSION.tar.%%TARBALL-COMPRESSION%%.sig" 'gcc.tar.%%TARBALL-COMPRESSION%%.sig'; \
-	_fetch "gcc-$GCC_VERSION/gcc-$GCC_VERSION.tar.%%TARBALL-COMPRESSION%%" 'gcc.tar.%%TARBALL-COMPRESSION%%'; \
+	_fetch "gcc-$GCC_VERSION/gcc-$GCC_VERSION.tar.%%TARBALL-COMPRESSION%%.sig" 'gcc.tar.%%TARBALL-COMPRESSION%%.sig' \
+# 6.5.0 (https://mirrors.kernel.org/gnu/gcc/6.5.0/), no gcc- prefix
+		|| _fetch "$GCC_VERSION/gcc-$GCC_VERSION.tar.%%TARBALL-COMPRESSION%%.sig"; \
+	_fetch "gcc-$GCC_VERSION/gcc-$GCC_VERSION.tar.%%TARBALL-COMPRESSION%%" 'gcc.tar.%%TARBALL-COMPRESSION%%' \
+		|| _fetch "$GCC_VERSION/gcc-$GCC_VERSION.tar.%%TARBALL-COMPRESSION%%" 'gcc.tar.%%TARBALL-COMPRESSION%%'; \
 	gpg --batch --verify gcc.tar.%%TARBALL-COMPRESSION%%.sig gcc.tar.%%TARBALL-COMPRESSION%%; \
 	mkdir -p /usr/src/gcc; \
 	tar -xf gcc.tar.%%TARBALL-COMPRESSION%% -C /usr/src/gcc --strip-components=1; \

--- a/update.sh
+++ b/update.sh
@@ -35,8 +35,8 @@ travisEnv=
 for version in "${versions[@]}"; do
 	travisEnv='\n  - VERSION='"$version$travisEnv"
 
-	fullVersion="$(grep '<a href="gcc-'"$version." "$packages" | sed -r 's!.*<a href="gcc-([^"/]+)/?".*!\1!' | sort -V | tail -1)"
-	lastModified="$(grep -m1 '<a href="gcc-'"$fullVersion"'/"' "$packages" | awk -F '  +' '{ print $2 }')"
+	fullVersion="$(grep -E '<a href="(gcc-)?'"$version." "$packages" | sed -r 's!.*<a href="(gcc-)?([^"/]+)/?".*!\2!' | sort -V | tail -1)"
+	lastModified="$(grep -Em1 '<a href="(gcc-)?'"$fullVersion"'/"' "$packages" | awk -F '  +' '{ print $2 }')"
 	lastModified="$(date -d "$lastModified" +"$dateFormat")"
 
 	releaseAge="$(( $today - $(date +'%s' -d "$lastModified") ))"
@@ -49,7 +49,10 @@ for version in "${versions[@]}"; do
 
 	compression=
 	for tryCompression in xz bz2 gz; do
-		if wget --quiet --spider "$packagesUrl/gcc-$fullVersion/gcc-$fullVersion.tar.$tryCompression"; then
+		if \
+			wget --quiet --spider "$packagesUrl/gcc-$fullVersion/gcc-$fullVersion.tar.$tryCompression" \
+			|| wget --quiet --spider "$packagesUrl/$fullVersion/gcc-$fullVersion.tar.$tryCompression" \
+		; then
 			compression="$tryCompression"
 			break
 		fi


### PR DESCRIPTION
This release updates the mirror structure from ".../gcc-VERSION/gcc-VERSION.tar..." to ".../VERSION/gcc-VERSION.tar...".

I have successfully build-tested `6/`, but not any of the others (I see no reason for them to fail, really).