### PR TITLE
Adjust "Docker EOL" period to 18 months

### DIFF
--- a/5/Dockerfile
+++ b/5/Dockerfile
@@ -39,7 +39,7 @@ ENV GCC_MIRRORS \
 
 # Last Modified: 2017-10-10
 ENV GCC_VERSION 5.5.0
-# Docker EOL: 2018-10-10
+# Docker EOL: 2019-04-10
 
 RUN set -ex; \
 	\

--- a/6/Dockerfile
+++ b/6/Dockerfile
@@ -39,7 +39,7 @@ ENV GCC_MIRRORS \
 
 # Last Modified: 2018-10-30
 ENV GCC_VERSION 6.5.0
-# Docker EOL: 2019-10-30
+# Docker EOL: 2020-04-30
 
 RUN set -ex; \
 	\

--- a/7/Dockerfile
+++ b/7/Dockerfile
@@ -39,7 +39,7 @@ ENV GCC_MIRRORS \
 
 # Last Modified: 2018-01-25
 ENV GCC_VERSION 7.3.0
-# Docker EOL: 2019-01-25
+# Docker EOL: 2019-07-25
 
 RUN set -ex; \
 	\

--- a/8/Dockerfile
+++ b/8/Dockerfile
@@ -39,7 +39,7 @@ ENV GCC_MIRRORS \
 
 # Last Modified: 2018-07-26
 ENV GCC_VERSION 8.2.0
-# Docker EOL: 2019-07-26
+# Docker EOL: 2020-01-26
 
 RUN set -ex; \
 	\

--- a/update.sh
+++ b/update.sh
@@ -20,10 +20,10 @@ packagesUrl='https://mirrors.kernel.org/gnu/gcc/' # the actual HTML of the page 
 packages="$(echo "$packagesUrl" | sed -r 's/[^a-zA-Z.-]+/-/g')"
 curl -fsSL "$packagesUrl" > "$packages"
 
-# our own "supported" window is 1 year from the most recent release because upstream doesn't have a good guideline, but appears to only release maintenance updates for 2-3 years after the initial release
-# in addition, maintenance releases are _usually_ less than a year apart; from 4.7+ there's only one outlier, and it's 4.7.3->4.7.4 at ~14 months
+# our own "supported" window is 18 months from the most recent release because upstream doesn't have a good guideline, but appears to only release maintenance updates for 2-3 years after the initial release
+# in addition, maintenance releases are _usually_ less than a year apart; from 4.7+ there's a handful of outliers, like 4.7.3->4.7.4 at ~14 months, 6.4->6.5 at ~15 months, etc
 export TZ=UTC
-eolPeriod='1 year'
+eolPeriod='18 months'
 today="$(date +'%s')"
 eolAgo="$(date +'%s' -d "$(date -d "@$today") - $eolPeriod")"
 eolAge="$(( $today - $eolAgo ))"


### PR DESCRIPTION
For context, the 6.5.0 update would've been missed entirely if we'd actually keep the "Docker EOL" date on 6.4.0 of 2018-07-04 and this isn't the first time our being lax on enforcing this "Docker EOL" has caught another update, so bumping this period makes sense IMO.