### PR TITLE
Remove gcc source to save space.

### DIFF
--- a/5/Dockerfile
+++ b/5/Dockerfile
@@ -127,7 +127,7 @@ RUN set -ex; \
 	\
 	cd ..; \
 	\
-	rm -rf "$dir"; \
+	rm -rf "$dir" /usr/src/gcc; \
 	\
 	apt-mark auto '.*' > /dev/null; \
 	[ -z "$savedAptMark" ] || apt-mark manual $savedAptMark; \

--- a/6/Dockerfile
+++ b/6/Dockerfile
@@ -127,7 +127,7 @@ RUN set -ex; \
 	\
 	cd ..; \
 	\
-	rm -rf "$dir"; \
+	rm -rf "$dir" /usr/src/gcc; \
 	\
 	apt-mark auto '.*' > /dev/null; \
 	[ -z "$savedAptMark" ] || apt-mark manual $savedAptMark; \

--- a/7/Dockerfile
+++ b/7/Dockerfile
@@ -127,7 +127,7 @@ RUN set -ex; \
 	\
 	cd ..; \
 	\
-	rm -rf "$dir"; \
+	rm -rf "$dir" /usr/src/gcc; \
 	\
 	apt-mark auto '.*' > /dev/null; \
 	[ -z "$savedAptMark" ] || apt-mark manual $savedAptMark; \

--- a/8/Dockerfile
+++ b/8/Dockerfile
@@ -127,7 +127,7 @@ RUN set -ex; \
 	\
 	cd ..; \
 	\
-	rm -rf "$dir"; \
+	rm -rf "$dir" /usr/src/gcc; \
 	\
 	apt-mark auto '.*' > /dev/null; \
 	[ -z "$savedAptMark" ] || apt-mark manual $savedAptMark; \

--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -127,7 +127,7 @@ RUN set -ex; \
 	\
 	cd ..; \
 	\
-	rm -rf "$dir"; \
+	rm -rf "$dir" /usr/src/gcc; \
 	\
 	apt-mark auto '.*' > /dev/null; \
 	[ -z "$savedAptMark" ] || apt-mark manual $savedAptMark; \


### PR DESCRIPTION
Fixes #51

Did one "quick" build to show size (other versions should be similar magnitude):
```console
REPOSITORY          TAG                 IMAGE ID            CREATED             SIZE
gcc                 8-test              e8142bfc87ae        About an hour ago   1.15GB
gcc                 8                   0080a63632e8        9 days ago          1.68GB
```