### PR TITLE
added some more cleanup tweaks

### DIFF
--- a/6/Dockerfile
+++ b/6/Dockerfile
@@ -7,7 +7,14 @@ RUN set -ex; \
 			gnupg \
 			dirmngr \
 		; \
-		rm -rf /var/lib/apt/lists/*; \
+		apt-get clean; \
+		rm -rf \
+			/var/lib/apt/lists/* \
+			/tmp/* \
+        		/var/tmp/* \
+        		/usr/share/man \
+        		/usr/share/doc \
+        		/usr/share/doc-base; \
 	fi
 
 # https://gcc.gnu.org/mirrors.html
@@ -49,7 +56,14 @@ RUN set -ex; \
 		dpkg-dev \
 		flex \
 	; \
-	rm -r /var/lib/apt/lists/*; \
+	apt-get clean; \
+	rm -rf \
+		/var/lib/apt/lists/* \
+		/tmp/* \
+        	/var/tmp/* \
+        	/usr/share/man \
+        	/usr/share/doc \
+        	/usr/share/doc-base; \
 	\
 	_fetch() { \
 		local fetch="$1"; shift; \

--- a/7/Dockerfile
+++ b/7/Dockerfile
@@ -7,7 +7,14 @@ RUN set -ex; \
 			gnupg \
 			dirmngr \
 		; \
-		rm -rf /var/lib/apt/lists/*; \
+		apt-get clean; \
+		rm -rf \
+			/var/lib/apt/lists/* \
+			/tmp/* \
+        		/var/tmp/* \
+        		/usr/share/man \
+        		/usr/share/doc \
+        		/usr/share/doc-base; \
 	fi
 
 # https://gcc.gnu.org/mirrors.html
@@ -49,7 +56,14 @@ RUN set -ex; \
 		dpkg-dev \
 		flex \
 	; \
-	rm -r /var/lib/apt/lists/*; \
+	apt-get clean; \
+	rm -rf \
+		/var/lib/apt/lists/* \
+		/tmp/* \
+        	/var/tmp/* \
+        	/usr/share/man \
+        	/usr/share/doc \
+        	/usr/share/doc-base; \
 	\
 	_fetch() { \
 		local fetch="$1"; shift; \

--- a/8/Dockerfile
+++ b/8/Dockerfile
@@ -7,7 +7,14 @@ RUN set -ex; \
 			gnupg \
 			dirmngr \
 		; \
-		rm -rf /var/lib/apt/lists/*; \
+		apt-get clean; \
+		rm -rf \
+			/var/lib/apt/lists/* \
+			/tmp/* \
+        		/var/tmp/* \
+        		/usr/share/man \
+        		/usr/share/doc \
+        		/usr/share/doc-base; \
 	fi
 
 # https://gcc.gnu.org/mirrors.html
@@ -49,7 +56,14 @@ RUN set -ex; \
 		dpkg-dev \
 		flex \
 	; \
-	rm -r /var/lib/apt/lists/*; \
+	apt-get clean; \
+	rm -rf \
+		/var/lib/apt/lists/* \
+		/tmp/* \
+        	/var/tmp/* \
+        	/usr/share/man \
+        	/usr/share/doc \
+        	/usr/share/doc-base; \
 	\
 	_fetch() { \
 		local fetch="$1"; shift; \

--- a/9/Dockerfile
+++ b/9/Dockerfile
@@ -7,7 +7,14 @@ RUN set -ex; \
 			gnupg \
 			dirmngr \
 		; \
-		rm -rf /var/lib/apt/lists/*; \
+		apt-get clean; \
+		rm -rf \
+			/var/lib/apt/lists/* \
+			/tmp/* \
+        		/var/tmp/* \
+        		/usr/share/man \
+        		/usr/share/doc \
+        		/usr/share/doc-base; \
 	fi
 
 # https://gcc.gnu.org/mirrors.html
@@ -49,7 +56,14 @@ RUN set -ex; \
 		dpkg-dev \
 		flex \
 	; \
-	rm -r /var/lib/apt/lists/*; \
+	apt-get clean; \
+	rm -rf \
+		/var/lib/apt/lists/* \
+		/tmp/* \
+        	/var/tmp/* \
+        	/usr/share/man \
+        	/usr/share/doc \
+        	/usr/share/doc-base; \
 	\
 	_fetch() { \
 		local fetch="$1"; shift; \

--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -7,7 +7,14 @@ RUN set -ex; \
 			gnupg \
 			dirmngr \
 		; \
-		rm -rf /var/lib/apt/lists/*; \
+		apt-get clean; \
+		rm -rf \
+			/var/lib/apt/lists/* \
+			/tmp/* \
+        		/var/tmp/* \
+        		/usr/share/man \
+        		/usr/share/doc \
+        		/usr/share/doc-base; \
 	fi
 
 # https://gcc.gnu.org/mirrors.html
@@ -49,7 +56,14 @@ RUN set -ex; \
 		dpkg-dev \
 		flex \
 	; \
-	rm -r /var/lib/apt/lists/*; \
+	apt-get clean; \
+	rm -rf \
+		/var/lib/apt/lists/* \
+		/tmp/* \
+        	/var/tmp/* \
+        	/usr/share/man \
+        	/usr/share/doc \
+        	/usr/share/doc-base; \
 	\
 	_fetch() { \
 		local fetch="$1"; shift; \


### PR DESCRIPTION
More cleanup tweaks using 

1. apt-get clean 

2. rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*

removing downloaded packages and packages list will free up some space ,

results in smaller image size.