### PR TITLE
Fix ldconfig for GCC installs

### DIFF
--- a/10/Dockerfile
+++ b/10/Dockerfile
@@ -141,9 +141,10 @@ RUN set -ex; \
 	[ -z "$savedAptMark" ] || apt-mark manual $savedAptMark; \
 	apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false
 
-# gcc installs .so files in /usr/local/lib64...
+# gcc installs .so files in /usr/local/lib64 (and /usr/local/lib)...
 RUN set -ex; \
-	echo '/usr/local/lib64' > /etc/ld.so.conf.d/local-lib64.conf; \
+# this filename needs to sort higher than all the architecture filenames ("aarch64-...", "armeabi...", etc)
+	{ echo '/usr/local/lib64'; echo '/usr/local/lib'; } > /etc/ld.so.conf.d/000-local-lib.conf; \
 	ldconfig -v
 
 # ensure that alternatives are pointing to the new compiler and that old one is no longer used

--- a/11/Dockerfile
+++ b/11/Dockerfile
@@ -141,9 +141,10 @@ RUN set -ex; \
 	[ -z "$savedAptMark" ] || apt-mark manual $savedAptMark; \
 	apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false
 
-# gcc installs .so files in /usr/local/lib64...
+# gcc installs .so files in /usr/local/lib64 (and /usr/local/lib)...
 RUN set -ex; \
-	echo '/usr/local/lib64' > /etc/ld.so.conf.d/local-lib64.conf; \
+# this filename needs to sort higher than all the architecture filenames ("aarch64-...", "armeabi...", etc)
+	{ echo '/usr/local/lib64'; echo '/usr/local/lib'; } > /etc/ld.so.conf.d/000-local-lib.conf; \
 	ldconfig -v
 
 # ensure that alternatives are pointing to the new compiler and that old one is no longer used

--- a/8/Dockerfile
+++ b/8/Dockerfile
@@ -141,9 +141,10 @@ RUN set -ex; \
 	[ -z "$savedAptMark" ] || apt-mark manual $savedAptMark; \
 	apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false
 
-# gcc installs .so files in /usr/local/lib64...
+# gcc installs .so files in /usr/local/lib64 (and /usr/local/lib)...
 RUN set -ex; \
-	echo '/usr/local/lib64' > /etc/ld.so.conf.d/local-lib64.conf; \
+# this filename needs to sort higher than all the architecture filenames ("aarch64-...", "armeabi...", etc)
+	{ echo '/usr/local/lib64'; echo '/usr/local/lib'; } > /etc/ld.so.conf.d/000-local-lib.conf; \
 	ldconfig -v
 
 # ensure that alternatives are pointing to the new compiler and that old one is no longer used

--- a/9/Dockerfile
+++ b/9/Dockerfile
@@ -141,9 +141,10 @@ RUN set -ex; \
 	[ -z "$savedAptMark" ] || apt-mark manual $savedAptMark; \
 	apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false
 
-# gcc installs .so files in /usr/local/lib64...
+# gcc installs .so files in /usr/local/lib64 (and /usr/local/lib)...
 RUN set -ex; \
-	echo '/usr/local/lib64' > /etc/ld.so.conf.d/local-lib64.conf; \
+# this filename needs to sort higher than all the architecture filenames ("aarch64-...", "armeabi...", etc)
+	{ echo '/usr/local/lib64'; echo '/usr/local/lib'; } > /etc/ld.so.conf.d/000-local-lib.conf; \
 	ldconfig -v
 
 # ensure that alternatives are pointing to the new compiler and that old one is no longer used

--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -135,9 +135,10 @@ RUN set -ex; \
 	[ -z "$savedAptMark" ] || apt-mark manual $savedAptMark; \
 	apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false
 
-# gcc installs .so files in /usr/local/lib64...
+# gcc installs .so files in /usr/local/lib64 (and /usr/local/lib)...
 RUN set -ex; \
-	echo '/usr/local/lib64' > /etc/ld.so.conf.d/local-lib64.conf; \
+# this filename needs to sort higher than all the architecture filenames ("aarch64-...", "armeabi...", etc)
+	{ echo '/usr/local/lib64'; echo '/usr/local/lib'; } > /etc/ld.so.conf.d/000-local-lib.conf; \
 	ldconfig -v
 
 # ensure that alternatives are pointing to the new compiler and that old one is no longer used


### PR DESCRIPTION
Fixes https://github.com/docker-library/gcc/issues/75

Without this fix I have to have a derived image with:
```Dockerfile
RUN rm /etc/ld.so.conf.d/local-lib64.conf && sed -i '1s/^/\/usr\/local\/lib64\n/' /etc/ld.so.conf && ldconfig
```

which gives me the correct order of `libstdc++`:
```console
$ ldconfig -p | grep libstdc++
        libstdc++.so.6 (libc6,AArch64) => /usr/local/lib64/libstdc++.so.6
        libstdc++.so.6 (libc6,AArch64) => /usr/lib/aarch64-linux-gnu/libstdc++.so.6
        libstdc++.so (libc6,AArch64) => /usr/local/lib64/libstdc++.so
```