### PR TITLE
Changes necessary for SOCKS5 proxy support

### DIFF
--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -29,7 +29,9 @@ ENV GPG_KEYS \
 
 RUN set -ex; \
 	for key in $GPG_KEYS; do \
-		gpg --batch --keyserver keyserver.ubuntu.com --recv-keys "$key"; \
+                curl -sSL \
+			"http://keyserver.ubuntu.com/pks/lookup?op=get&search=0x$key" \
+			| gpg --import; \
 	done
 
 # https://gcc.gnu.org/mirrors.html
@@ -84,7 +86,7 @@ RUN set -ex; \
 	\
 # explicitly update autoconf config.guess and config.sub so they support more arches/libcs
 	for f in config.guess config.sub; do \
-		wget -O "$f" "https://git.savannah.gnu.org/cgit/config.git/plain/$f?id=7d3d27baf8107b630586c962c057e22149653deb"; \
+		curl -sL -o "$f" "https://git.savannah.gnu.org/cgit/config.git/plain/$f?id=7d3d27baf8107b630586c962c057e22149653deb"; \
 # find any more (shallow) copies of the file we grabbed and update them too
 		find -mindepth 2 -name "$f" -exec cp -v "$f" '{}' ';'; \
 	done; \

--- a/apply-templates.sh
+++ b/apply-templates.sh
@@ -7,7 +7,7 @@ jqt='.jq-template.awk'
 if [ -n "${BASHBREW_SCRIPTS:-}" ]; then
 	jqt="$BASHBREW_SCRIPTS/jq-template.awk"
 elif [ "$BASH_SOURCE" -nt "$jqt" ]; then
-	wget -qO "$jqt" 'https://github.com/docker-library/bashbrew/raw/ac3e8e9541cb362a579b05bec41dd40d1df1c6e6/scripts/jq-template.awk'
+	curl -sL -o "$jqt" 'https://github.com/docker-library/bashbrew/raw/ac3e8e9541cb362a579b05bec41dd40d1df1c6e6/scripts/jq-template.awk'
 fi
 
 if [ "$#" -eq 0 ]; then


### PR DESCRIPTION
Using curl instead of internal gpg downloader and instead of wget, because both do not respect the host system SOCKS5 proxy settings, while curl is the only download tool which does