### PR TITLE
Switch to "$GITHUB_OUTPUT"; update actions/checkout to v3

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
     outputs:
       strategy: ${{ steps.generate-jobs.outputs.strategy }}
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v3
       - id: generate-jobs
         name: Generate Jobs
         run: |
@@ -26,8 +26,8 @@ jobs:
           strategy="$(~/bashbrew/scripts/github-actions/generate.sh)"
           # if we're FROM jessie, include a ulimit so apt-get isn't slow (https://bugs.launchpad.net/bugs/1332440)
           strategy="$(jq -c '.matrix.include = [ .matrix.include[] | if .meta.froms[] | test("jessie") then .runs.build |= gsub("docker build"; "docker build --ulimit nofile=1024:1024") else . end ]' <<<"$strategy")"
+          echo "strategy=$strategy" >> "$GITHUB_OUTPUT"
           jq . <<<"$strategy" # sanity check / debugging aid
-          echo "::set-output name=strategy::$strategy"
 
   test:
     needs: generate-jobs
@@ -35,7 +35,7 @@ jobs:
     name: ${{ matrix.name }}
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v3
       - name: Prepare Environment
         run: ${{ matrix.runs.prepare }}
       - name: Pull Dependencies

--- a/.github/workflows/verify-templating.yml
+++ b/.github/workflows/verify-templating.yml
@@ -13,7 +13,7 @@ jobs:
     name: Check For Uncomitted Changes
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Apply Templates
         run: ./apply-templates.sh
       - name: Check Git Status


### PR DESCRIPTION
- https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands
- https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#setting-an-output-parameter