### PR TITLE
Remove explicit `dirmngr` reference

### DIFF
--- a/10/Dockerfile
+++ b/10/Dockerfile
@@ -6,16 +6,6 @@
 
 FROM buildpack-deps:bullseye
 
-RUN set -ex; \
-	if ! command -v gpg > /dev/null; then \
-		apt-get update; \
-		apt-get install -y --no-install-recommends \
-			gnupg \
-			dirmngr \
-		; \
-		rm -rf /var/lib/apt/lists/*; \
-	fi
-
 # https://gcc.gnu.org/mirrors.html
 ENV GPG_KEYS \
 # 1024D/745C015A 1999-11-09 Gerald Pfeifer <gerald@pfeifer.com>
@@ -34,6 +24,11 @@ ENV GPG_KEYS \
 	D3A93CAD751C2AF4F8C7AD516C35B99309B5FA62
 
 RUN set -ex; \
+	apt-get update; \
+	apt-get install -y --no-install-recommends \
+		gnupg \
+	; \
+	rm -rf /var/lib/apt/lists/*; \
 	for key in $GPG_KEYS; do \
 		gpg --batch --keyserver keyserver.ubuntu.com --recv-keys "$key"; \
 	done

--- a/11/Dockerfile
+++ b/11/Dockerfile
@@ -6,16 +6,6 @@
 
 FROM buildpack-deps:bullseye
 
-RUN set -ex; \
-	if ! command -v gpg > /dev/null; then \
-		apt-get update; \
-		apt-get install -y --no-install-recommends \
-			gnupg \
-			dirmngr \
-		; \
-		rm -rf /var/lib/apt/lists/*; \
-	fi
-
 # https://gcc.gnu.org/mirrors.html
 ENV GPG_KEYS \
 # 1024D/745C015A 1999-11-09 Gerald Pfeifer <gerald@pfeifer.com>
@@ -34,6 +24,11 @@ ENV GPG_KEYS \
 	D3A93CAD751C2AF4F8C7AD516C35B99309B5FA62
 
 RUN set -ex; \
+	apt-get update; \
+	apt-get install -y --no-install-recommends \
+		gnupg \
+	; \
+	rm -rf /var/lib/apt/lists/*; \
 	for key in $GPG_KEYS; do \
 		gpg --batch --keyserver keyserver.ubuntu.com --recv-keys "$key"; \
 	done

--- a/12/Dockerfile
+++ b/12/Dockerfile
@@ -6,16 +6,6 @@
 
 FROM buildpack-deps:bullseye
 
-RUN set -ex; \
-	if ! command -v gpg > /dev/null; then \
-		apt-get update; \
-		apt-get install -y --no-install-recommends \
-			gnupg \
-			dirmngr \
-		; \
-		rm -rf /var/lib/apt/lists/*; \
-	fi
-
 # https://gcc.gnu.org/mirrors.html
 ENV GPG_KEYS \
 # 1024D/745C015A 1999-11-09 Gerald Pfeifer <gerald@pfeifer.com>
@@ -34,6 +24,11 @@ ENV GPG_KEYS \
 	D3A93CAD751C2AF4F8C7AD516C35B99309B5FA62
 
 RUN set -ex; \
+	apt-get update; \
+	apt-get install -y --no-install-recommends \
+		gnupg \
+	; \
+	rm -rf /var/lib/apt/lists/*; \
 	for key in $GPG_KEYS; do \
 		gpg --batch --keyserver keyserver.ubuntu.com --recv-keys "$key"; \
 	done

--- a/13/Dockerfile
+++ b/13/Dockerfile
@@ -6,16 +6,6 @@
 
 FROM buildpack-deps:bookworm
 
-RUN set -ex; \
-	if ! command -v gpg > /dev/null; then \
-		apt-get update; \
-		apt-get install -y --no-install-recommends \
-			gnupg \
-			dirmngr \
-		; \
-		rm -rf /var/lib/apt/lists/*; \
-	fi
-
 # https://gcc.gnu.org/mirrors.html
 ENV GPG_KEYS \
 # 1024D/745C015A 1999-11-09 Gerald Pfeifer <gerald@pfeifer.com>
@@ -34,6 +24,11 @@ ENV GPG_KEYS \
 	D3A93CAD751C2AF4F8C7AD516C35B99309B5FA62
 
 RUN set -ex; \
+	apt-get update; \
+	apt-get install -y --no-install-recommends \
+		gnupg \
+	; \
+	rm -rf /var/lib/apt/lists/*; \
 	for key in $GPG_KEYS; do \
 		gpg --batch --keyserver keyserver.ubuntu.com --recv-keys "$key"; \
 	done

--- a/9/Dockerfile
+++ b/9/Dockerfile
@@ -6,16 +6,6 @@
 
 FROM buildpack-deps:bullseye
 
-RUN set -ex; \
-	if ! command -v gpg > /dev/null; then \
-		apt-get update; \
-		apt-get install -y --no-install-recommends \
-			gnupg \
-			dirmngr \
-		; \
-		rm -rf /var/lib/apt/lists/*; \
-	fi
-
 # https://gcc.gnu.org/mirrors.html
 ENV GPG_KEYS \
 # 1024D/745C015A 1999-11-09 Gerald Pfeifer <gerald@pfeifer.com>
@@ -34,6 +24,11 @@ ENV GPG_KEYS \
 	D3A93CAD751C2AF4F8C7AD516C35B99309B5FA62
 
 RUN set -ex; \
+	apt-get update; \
+	apt-get install -y --no-install-recommends \
+		gnupg \
+	; \
+	rm -rf /var/lib/apt/lists/*; \
 	for key in $GPG_KEYS; do \
 		gpg --batch --keyserver keyserver.ubuntu.com --recv-keys "$key"; \
 	done

--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -1,15 +1,5 @@
 FROM buildpack-deps:{{ .debian.version }}
 
-RUN set -ex; \
-	if ! command -v gpg > /dev/null; then \
-		apt-get update; \
-		apt-get install -y --no-install-recommends \
-			gnupg \
-			dirmngr \
-		; \
-		rm -rf /var/lib/apt/lists/*; \
-	fi
-
 # https://gcc.gnu.org/mirrors.html
 ENV GPG_KEYS \
 # 1024D/745C015A 1999-11-09 Gerald Pfeifer <gerald@pfeifer.com>
@@ -28,6 +18,11 @@ ENV GPG_KEYS \
 	D3A93CAD751C2AF4F8C7AD516C35B99309B5FA62
 
 RUN set -ex; \
+	apt-get update; \
+	apt-get install -y --no-install-recommends \
+		gnupg \
+	; \
+	rm -rf /var/lib/apt/lists/*; \
 	for key in $GPG_KEYS; do \
 		gpg --batch --keyserver keyserver.ubuntu.com --recv-keys "$key"; \
 	done


### PR DESCRIPTION
This is pulled in automatically via `gnupg`, and moved from `Recommends` to `Depends` in https://salsa.debian.org/debian/gnupg2/-/commit/99474ad900a8bcdd0e7b68f986fec0013fc01470, which has been part of `src:gnupg2` since 2.1.21-4 (and every supported version of both Debian _and_ Ubuntu have 2.2.x 😇).