### PR TITLE
Downgrade 9 and 10 to bullseye

### DIFF
--- a/10/Dockerfile
+++ b/10/Dockerfile
@@ -4,7 +4,7 @@
 # PLEASE DO NOT EDIT IT DIRECTLY.
 #
 
-FROM buildpack-deps:bookworm
+FROM buildpack-deps:bullseye
 
 # https://gcc.gnu.org/mirrors.html
 ENV GPG_KEYS \
@@ -134,7 +134,9 @@ RUN set -ex; \
 RUN set -ex; \
 # this filename needs to sort higher than all the architecture filenames ("aarch64-...", "armeabi...", etc)
 	{ echo '/usr/local/lib64'; echo '/usr/local/lib'; } > /etc/ld.so.conf.d/000-local-lib.conf; \
-	ldconfig -v
+	ldconfig -v; \
+	# smoke test to make sure the libs from /usr/local don't break Debian
+	apt-get --version
 
 # ensure that alternatives are pointing to the new compiler and that old one is no longer used
 RUN set -ex; \

--- a/11/Dockerfile
+++ b/11/Dockerfile
@@ -135,7 +135,9 @@ RUN set -ex; \
 RUN set -ex; \
 # this filename needs to sort higher than all the architecture filenames ("aarch64-...", "armeabi...", etc)
 	{ echo '/usr/local/lib64'; echo '/usr/local/lib'; } > /etc/ld.so.conf.d/000-local-lib.conf; \
-	ldconfig -v
+	ldconfig -v; \
+	# smoke test to make sure the libs from /usr/local don't break Debian
+	apt-get --version
 
 # ensure that alternatives are pointing to the new compiler and that old one is no longer used
 RUN set -ex; \

--- a/12/Dockerfile
+++ b/12/Dockerfile
@@ -135,7 +135,9 @@ RUN set -ex; \
 RUN set -ex; \
 # this filename needs to sort higher than all the architecture filenames ("aarch64-...", "armeabi...", etc)
 	{ echo '/usr/local/lib64'; echo '/usr/local/lib'; } > /etc/ld.so.conf.d/000-local-lib.conf; \
-	ldconfig -v
+	ldconfig -v; \
+	# smoke test to make sure the libs from /usr/local don't break Debian
+	apt-get --version
 
 # ensure that alternatives are pointing to the new compiler and that old one is no longer used
 RUN set -ex; \

--- a/13/Dockerfile
+++ b/13/Dockerfile
@@ -135,7 +135,9 @@ RUN set -ex; \
 RUN set -ex; \
 # this filename needs to sort higher than all the architecture filenames ("aarch64-...", "armeabi...", etc)
 	{ echo '/usr/local/lib64'; echo '/usr/local/lib'; } > /etc/ld.so.conf.d/000-local-lib.conf; \
-	ldconfig -v
+	ldconfig -v; \
+	# smoke test to make sure the libs from /usr/local don't break Debian
+	apt-get --version
 
 # ensure that alternatives are pointing to the new compiler and that old one is no longer used
 RUN set -ex; \

--- a/9/Dockerfile
+++ b/9/Dockerfile
@@ -4,7 +4,7 @@
 # PLEASE DO NOT EDIT IT DIRECTLY.
 #
 
-FROM buildpack-deps:bookworm
+FROM buildpack-deps:bullseye
 
 # https://gcc.gnu.org/mirrors.html
 ENV GPG_KEYS \
@@ -134,7 +134,9 @@ RUN set -ex; \
 RUN set -ex; \
 # this filename needs to sort higher than all the architecture filenames ("aarch64-...", "armeabi...", etc)
 	{ echo '/usr/local/lib64'; echo '/usr/local/lib'; } > /etc/ld.so.conf.d/000-local-lib.conf; \
-	ldconfig -v
+	ldconfig -v; \
+	# smoke test to make sure the libs from /usr/local don't break Debian
+	apt-get --version
 
 # ensure that alternatives are pointing to the new compiler and that old one is no longer used
 RUN set -ex; \

--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -133,7 +133,9 @@ RUN set -ex; \
 RUN set -ex; \
 # this filename needs to sort higher than all the architecture filenames ("aarch64-...", "armeabi...", etc)
 	{ echo '/usr/local/lib64'; echo '/usr/local/lib'; } > /etc/ld.so.conf.d/000-local-lib.conf; \
-	ldconfig -v
+	ldconfig -v; \
+	# smoke test to make sure the libs from /usr/local don't break Debian
+	apt-get --version
 
 # ensure that alternatives are pointing to the new compiler and that old one is no longer used
 RUN set -ex; \

--- a/versions.json
+++ b/versions.json
@@ -2,7 +2,7 @@
   "10": {
     "compression": "xz",
     "debian": {
-      "version": "bookworm"
+      "version": "bullseye"
     },
     "eol": "2023-12-28",
     "lastModified": "2022-06-28",
@@ -38,7 +38,7 @@
   "9": {
     "compression": "xz",
     "debian": {
-      "version": "bookworm"
+      "version": "bullseye"
     },
     "eol": "2023-11-27",
     "lastModified": "2022-05-27",

--- a/versions.sh
+++ b/versions.sh
@@ -3,6 +3,11 @@ set -Eeuo pipefail
 
 # defaultDebianSuite gets auto-declared below
 declare -A debianSuites=(
+# the libc created by gcc is too old for a newer Debian
+# $ apt --version
+# apt: /usr/local/lib64/libstdc++.so.6: version `GLIBCXX_3.4.29' not found
+	[10]="bullseye"
+	[9]="bullseye"
 )
 
 cd "$(dirname "$(readlink -f "$BASH_SOURCE")")"


### PR DESCRIPTION
Add smoke test to help prevent the same error
```console
$ apt-get --version
apt-get: /usr/local/lib64/libstdc++.so.6: version `GLIBCXX_3.4.29' not found (required by /lib/x86_64-linux-gnu/libapt-private.so.0.0)
apt-get: /usr/local/lib64/libstdc++.so.6: version `GLIBCXX_3.4.29' not found (required by /lib/x86_64-linux-gnu/libapt-pkg.so.6.0)
```

Fixes #93