### PR TITLE
Downgrade gcc 11 back to bullseye

### DIFF
--- a/10/Dockerfile
+++ b/10/Dockerfile
@@ -135,8 +135,14 @@ RUN set -ex; \
 # this filename needs to sort higher than all the architecture filenames ("aarch64-...", "armeabi...", etc)
 	{ echo '/usr/local/lib64'; echo '/usr/local/lib'; } > /etc/ld.so.conf.d/000-local-lib.conf; \
 	ldconfig -v; \
-	# smoke test to make sure the libs from /usr/local don't break Debian
-	apt-get --version
+	# the libc created by gcc might be too old for a newer Debian
+	# check that the Debian libstdc++ doesn't have newer requirements than the gcc one
+	bash -Eeuo pipefail -xc ' \
+		deb="$(strings /usr/lib/*/libstdc++.so* | grep "^GLIBC" | sort -u)"; \
+		gcc="$(strings /usr/local/lib*/libstdc++.so | grep "^GLIBC" | sort -u)"; \
+		diff="$(comm -23 <(cat <<<"$deb") <(cat <<<"$gcc"))"; \
+		test -z "$diff"; \
+	'
 
 # ensure that alternatives are pointing to the new compiler and that old one is no longer used
 RUN set -ex; \

--- a/11/Dockerfile
+++ b/11/Dockerfile
@@ -4,7 +4,7 @@
 # PLEASE DO NOT EDIT IT DIRECTLY.
 #
 
-FROM buildpack-deps:bookworm
+FROM buildpack-deps:bullseye
 
 # https://gcc.gnu.org/mirrors.html
 ENV GPG_KEYS \
@@ -136,8 +136,14 @@ RUN set -ex; \
 # this filename needs to sort higher than all the architecture filenames ("aarch64-...", "armeabi...", etc)
 	{ echo '/usr/local/lib64'; echo '/usr/local/lib'; } > /etc/ld.so.conf.d/000-local-lib.conf; \
 	ldconfig -v; \
-	# smoke test to make sure the libs from /usr/local don't break Debian
-	apt-get --version
+	# the libc created by gcc might be too old for a newer Debian
+	# check that the Debian libstdc++ doesn't have newer requirements than the gcc one
+	bash -Eeuo pipefail -xc ' \
+		deb="$(strings /usr/lib/*/libstdc++.so* | grep "^GLIBC" | sort -u)"; \
+		gcc="$(strings /usr/local/lib*/libstdc++.so | grep "^GLIBC" | sort -u)"; \
+		diff="$(comm -23 <(cat <<<"$deb") <(cat <<<"$gcc"))"; \
+		test -z "$diff"; \
+	'
 
 # ensure that alternatives are pointing to the new compiler and that old one is no longer used
 RUN set -ex; \

--- a/12/Dockerfile
+++ b/12/Dockerfile
@@ -136,8 +136,14 @@ RUN set -ex; \
 # this filename needs to sort higher than all the architecture filenames ("aarch64-...", "armeabi...", etc)
 	{ echo '/usr/local/lib64'; echo '/usr/local/lib'; } > /etc/ld.so.conf.d/000-local-lib.conf; \
 	ldconfig -v; \
-	# smoke test to make sure the libs from /usr/local don't break Debian
-	apt-get --version
+	# the libc created by gcc might be too old for a newer Debian
+	# check that the Debian libstdc++ doesn't have newer requirements than the gcc one
+	bash -Eeuo pipefail -xc ' \
+		deb="$(strings /usr/lib/*/libstdc++.so* | grep "^GLIBC" | sort -u)"; \
+		gcc="$(strings /usr/local/lib*/libstdc++.so | grep "^GLIBC" | sort -u)"; \
+		diff="$(comm -23 <(cat <<<"$deb") <(cat <<<"$gcc"))"; \
+		test -z "$diff"; \
+	'
 
 # ensure that alternatives are pointing to the new compiler and that old one is no longer used
 RUN set -ex; \

--- a/13/Dockerfile
+++ b/13/Dockerfile
@@ -136,8 +136,14 @@ RUN set -ex; \
 # this filename needs to sort higher than all the architecture filenames ("aarch64-...", "armeabi...", etc)
 	{ echo '/usr/local/lib64'; echo '/usr/local/lib'; } > /etc/ld.so.conf.d/000-local-lib.conf; \
 	ldconfig -v; \
-	# smoke test to make sure the libs from /usr/local don't break Debian
-	apt-get --version
+	# the libc created by gcc might be too old for a newer Debian
+	# check that the Debian libstdc++ doesn't have newer requirements than the gcc one
+	bash -Eeuo pipefail -xc ' \
+		deb="$(strings /usr/lib/*/libstdc++.so* | grep "^GLIBC" | sort -u)"; \
+		gcc="$(strings /usr/local/lib*/libstdc++.so | grep "^GLIBC" | sort -u)"; \
+		diff="$(comm -23 <(cat <<<"$deb") <(cat <<<"$gcc"))"; \
+		test -z "$diff"; \
+	'
 
 # ensure that alternatives are pointing to the new compiler and that old one is no longer used
 RUN set -ex; \

--- a/9/Dockerfile
+++ b/9/Dockerfile
@@ -135,8 +135,14 @@ RUN set -ex; \
 # this filename needs to sort higher than all the architecture filenames ("aarch64-...", "armeabi...", etc)
 	{ echo '/usr/local/lib64'; echo '/usr/local/lib'; } > /etc/ld.so.conf.d/000-local-lib.conf; \
 	ldconfig -v; \
-	# smoke test to make sure the libs from /usr/local don't break Debian
-	apt-get --version
+	# the libc created by gcc might be too old for a newer Debian
+	# check that the Debian libstdc++ doesn't have newer requirements than the gcc one
+	bash -Eeuo pipefail -xc ' \
+		deb="$(strings /usr/lib/*/libstdc++.so* | grep "^GLIBC" | sort -u)"; \
+		gcc="$(strings /usr/local/lib*/libstdc++.so | grep "^GLIBC" | sort -u)"; \
+		diff="$(comm -23 <(cat <<<"$deb") <(cat <<<"$gcc"))"; \
+		test -z "$diff"; \
+	'
 
 # ensure that alternatives are pointing to the new compiler and that old one is no longer used
 RUN set -ex; \

--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -134,8 +134,14 @@ RUN set -ex; \
 # this filename needs to sort higher than all the architecture filenames ("aarch64-...", "armeabi...", etc)
 	{ echo '/usr/local/lib64'; echo '/usr/local/lib'; } > /etc/ld.so.conf.d/000-local-lib.conf; \
 	ldconfig -v; \
-	# smoke test to make sure the libs from /usr/local don't break Debian
-	apt-get --version
+	# the libc created by gcc might be too old for a newer Debian
+	# check that the Debian libstdc++ doesn't have newer requirements than the gcc one
+	bash -Eeuo pipefail -xc ' \
+		deb="$(strings /usr/lib/*/libstdc++.so* | grep "^GLIBC" | sort -u)"; \
+		gcc="$(strings /usr/local/lib*/libstdc++.so | grep "^GLIBC" | sort -u)"; \
+		diff="$(comm -23 <(cat <<<"$deb") <(cat <<<"$gcc"))"; \
+		test -z "$diff"; \
+	'
 
 # ensure that alternatives are pointing to the new compiler and that old one is no longer used
 RUN set -ex; \

--- a/versions.json
+++ b/versions.json
@@ -11,7 +11,7 @@
   "11": {
     "compression": "xz",
     "debian": {
-      "version": "bookworm"
+      "version": "bullseye"
     },
     "eol": "2024-11-29",
     "lastModified": "2023-05-29",

--- a/versions.sh
+++ b/versions.sh
@@ -1,9 +1,17 @@
 #!/bin/bash
 set -Eeuo pipefail
 
+# the libc created by gcc might be too old for a newer Debian:
+# https://packages.debian.org/stable/gcc
+# bookworm: 12.2
+# bullseye: 10.2
+# buster: 8.3
+
 # defaultDebianSuite gets auto-declared below
 declare -A debianSuites=(
-# the libc created by gcc is too old for a newer Debian
+# $ convert
+# convert: /usr/local/lib64/libstdc++.so.6: version `GLIBCXX_3.4.30' not found
+	[11]='bullseye'
 # $ apt --version
 # apt: /usr/local/lib64/libstdc++.so.6: version `GLIBCXX_3.4.29' not found
 	[10]='bullseye'


### PR DESCRIPTION
Similar to https://github.com/docker-library/gcc/issues/94. Fixes https://github.com/docker-library/gcc/issues/96