### PR TITLE
generate-stackbrew-library.sh: add `Builder: buildkit`

### DIFF
--- a/generate-stackbrew-library.sh
+++ b/generate-stackbrew-library.sh
@@ -60,6 +60,7 @@ cat <<-EOH
 Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/gcc.git
+Builder: buildkit
 EOH
 
 # prints "$2$1$3$1...$N"


### PR DESCRIPTION
This allows using modern Dockerfile syntaxes in future.

The image on Docker Hub has been already built with BuildKit.