### PR TITLE
Use `abidiff` to verify ABI compatibility

### DIFF
--- a/10/Dockerfile
+++ b/10/Dockerfile
@@ -6,6 +6,14 @@
 
 FROM buildpack-deps:bullseye
 
+RUN set -eux; \
+	apt-get update; \
+	apt-get install -y --no-install-recommends \
+# install abigail-tools so we can use abidiff later to verify that we don't break Debian packages
+		abigail-tools \
+	; \
+	rm -rf /var/lib/apt/lists/*
+
 # https://gcc.gnu.org/mirrors.html
 ENV GPG_KEYS \
 # 1024D/745C015A 1999-11-09 Gerald Pfeifer <gerald@pfeifer.com>
@@ -134,12 +142,10 @@ RUN set -ex; \
 	ldconfig -v; \
 	# the libc created by gcc might be too old for a newer Debian
 	# check that the Debian libstdc++ doesn't have newer requirements than the gcc one
-	bash -Eeuo pipefail -xc ' \
-		deb="$(strings /usr/lib/*/libstdc++.so* | grep "^GLIBC" | sort -u)"; \
-		gcc="$(strings /usr/local/lib*/libstdc++.so | grep "^GLIBC" | sort -u)"; \
-		diff="$(comm -23 <(cat <<<"$deb") <(cat <<<"$gcc"))"; \
-		test -z "$diff"; \
-	'
+	deb="$(readlink -ve /usr/lib/*/libstdc++.so* | head -1)"; \
+	gcc="$(readlink -ve /usr/local/lib*/libstdc++.so | head -1)"; \
+# using LD_PRELOAD to make sure "abidiff" itself doesn't fail with the exact error we're trying to test for 😂😭
+	LD_PRELOAD="$deb" abidiff --no-added-syms "$deb" "$gcc"
 
 # ensure that alternatives are pointing to the new compiler and that old one is no longer used
 RUN set -ex; \

--- a/11/Dockerfile
+++ b/11/Dockerfile
@@ -6,6 +6,14 @@
 
 FROM buildpack-deps:bullseye
 
+RUN set -eux; \
+	apt-get update; \
+	apt-get install -y --no-install-recommends \
+# install abigail-tools so we can use abidiff later to verify that we don't break Debian packages
+		abigail-tools \
+	; \
+	rm -rf /var/lib/apt/lists/*
+
 # https://gcc.gnu.org/mirrors.html
 ENV GPG_KEYS \
 # 1024D/745C015A 1999-11-09 Gerald Pfeifer <gerald@pfeifer.com>
@@ -135,12 +143,10 @@ RUN set -ex; \
 	ldconfig -v; \
 	# the libc created by gcc might be too old for a newer Debian
 	# check that the Debian libstdc++ doesn't have newer requirements than the gcc one
-	bash -Eeuo pipefail -xc ' \
-		deb="$(strings /usr/lib/*/libstdc++.so* | grep "^GLIBC" | sort -u)"; \
-		gcc="$(strings /usr/local/lib*/libstdc++.so | grep "^GLIBC" | sort -u)"; \
-		diff="$(comm -23 <(cat <<<"$deb") <(cat <<<"$gcc"))"; \
-		test -z "$diff"; \
-	'
+	deb="$(readlink -ve /usr/lib/*/libstdc++.so* | head -1)"; \
+	gcc="$(readlink -ve /usr/local/lib*/libstdc++.so | head -1)"; \
+# using LD_PRELOAD to make sure "abidiff" itself doesn't fail with the exact error we're trying to test for 😂😭
+	LD_PRELOAD="$deb" abidiff --no-added-syms "$deb" "$gcc"
 
 # ensure that alternatives are pointing to the new compiler and that old one is no longer used
 RUN set -ex; \

--- a/12/Dockerfile
+++ b/12/Dockerfile
@@ -6,6 +6,14 @@
 
 FROM buildpack-deps:bookworm
 
+RUN set -eux; \
+	apt-get update; \
+	apt-get install -y --no-install-recommends \
+# install abigail-tools so we can use abidiff later to verify that we don't break Debian packages
+		abigail-tools \
+	; \
+	rm -rf /var/lib/apt/lists/*
+
 # https://gcc.gnu.org/mirrors.html
 ENV GPG_KEYS \
 # 1024D/745C015A 1999-11-09 Gerald Pfeifer <gerald@pfeifer.com>
@@ -135,12 +143,10 @@ RUN set -ex; \
 	ldconfig -v; \
 	# the libc created by gcc might be too old for a newer Debian
 	# check that the Debian libstdc++ doesn't have newer requirements than the gcc one
-	bash -Eeuo pipefail -xc ' \
-		deb="$(strings /usr/lib/*/libstdc++.so* | grep "^GLIBC" | sort -u)"; \
-		gcc="$(strings /usr/local/lib*/libstdc++.so | grep "^GLIBC" | sort -u)"; \
-		diff="$(comm -23 <(cat <<<"$deb") <(cat <<<"$gcc"))"; \
-		test -z "$diff"; \
-	'
+	deb="$(readlink -ve /usr/lib/*/libstdc++.so* | head -1)"; \
+	gcc="$(readlink -ve /usr/local/lib*/libstdc++.so | head -1)"; \
+# using LD_PRELOAD to make sure "abidiff" itself doesn't fail with the exact error we're trying to test for 😂😭
+	LD_PRELOAD="$deb" abidiff --no-added-syms "$deb" "$gcc"
 
 # ensure that alternatives are pointing to the new compiler and that old one is no longer used
 RUN set -ex; \

--- a/13/Dockerfile
+++ b/13/Dockerfile
@@ -6,6 +6,14 @@
 
 FROM buildpack-deps:bookworm
 
+RUN set -eux; \
+	apt-get update; \
+	apt-get install -y --no-install-recommends \
+# install abigail-tools so we can use abidiff later to verify that we don't break Debian packages
+		abigail-tools \
+	; \
+	rm -rf /var/lib/apt/lists/*
+
 # https://gcc.gnu.org/mirrors.html
 ENV GPG_KEYS \
 # 1024D/745C015A 1999-11-09 Gerald Pfeifer <gerald@pfeifer.com>
@@ -135,12 +143,10 @@ RUN set -ex; \
 	ldconfig -v; \
 	# the libc created by gcc might be too old for a newer Debian
 	# check that the Debian libstdc++ doesn't have newer requirements than the gcc one
-	bash -Eeuo pipefail -xc ' \
-		deb="$(strings /usr/lib/*/libstdc++.so* | grep "^GLIBC" | sort -u)"; \
-		gcc="$(strings /usr/local/lib*/libstdc++.so | grep "^GLIBC" | sort -u)"; \
-		diff="$(comm -23 <(cat <<<"$deb") <(cat <<<"$gcc"))"; \
-		test -z "$diff"; \
-	'
+	deb="$(readlink -ve /usr/lib/*/libstdc++.so* | head -1)"; \
+	gcc="$(readlink -ve /usr/local/lib*/libstdc++.so | head -1)"; \
+# using LD_PRELOAD to make sure "abidiff" itself doesn't fail with the exact error we're trying to test for 😂😭
+	LD_PRELOAD="$deb" abidiff --no-added-syms "$deb" "$gcc"
 
 # ensure that alternatives are pointing to the new compiler and that old one is no longer used
 RUN set -ex; \

--- a/14/Dockerfile
+++ b/14/Dockerfile
@@ -6,6 +6,14 @@
 
 FROM buildpack-deps:bookworm
 
+RUN set -eux; \
+	apt-get update; \
+	apt-get install -y --no-install-recommends \
+# install abigail-tools so we can use abidiff later to verify that we don't break Debian packages
+		abigail-tools \
+	; \
+	rm -rf /var/lib/apt/lists/*
+
 # https://gcc.gnu.org/mirrors.html
 ENV GPG_KEYS \
 # 1024D/745C015A 1999-11-09 Gerald Pfeifer <gerald@pfeifer.com>
@@ -135,14 +143,10 @@ RUN set -ex; \
 	ldconfig -v; \
 	# the libc created by gcc might be too old for a newer Debian
 	# check that the Debian libstdc++ doesn't have newer requirements than the gcc one
-	bash -Eeuo pipefail -xc ' \
-		deb="$(strings /usr/lib/*/libstdc++.so* | grep "^GLIBC" | sort -u)"; \
-		gcc="$(strings /usr/local/lib*/libstdc++.so | grep "^GLIBC" | sort -u)"; \
-# https://github.com/docker-library/gcc/pull/103#issuecomment-2099134740 (using "comm" to avoid accidental partial matches / hairy "grep" regex)
-		deb="$(comm -23 <(cat <<<"$deb") <(echo "GLIBC_2.16"))"; \
-		diff="$(comm -23 <(cat <<<"$deb") <(cat <<<"$gcc"))"; \
-		test -z "$diff"; \
-	'
+	deb="$(readlink -ve /usr/lib/*/libstdc++.so* | head -1)"; \
+	gcc="$(readlink -ve /usr/local/lib*/libstdc++.so | head -1)"; \
+# using LD_PRELOAD to make sure "abidiff" itself doesn't fail with the exact error we're trying to test for 😂😭
+	LD_PRELOAD="$deb" abidiff --no-added-syms "$deb" "$gcc"
 
 # ensure that alternatives are pointing to the new compiler and that old one is no longer used
 RUN set -ex; \

--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -1,5 +1,13 @@
 FROM buildpack-deps:{{ .debian.version }}
 
+RUN set -eux; \
+	apt-get update; \
+	apt-get install -y --no-install-recommends \
+# install abigail-tools so we can use abidiff later to verify that we don't break Debian packages
+		abigail-tools \
+	; \
+	rm -rf /var/lib/apt/lists/*
+
 # https://gcc.gnu.org/mirrors.html
 ENV GPG_KEYS \
 # 1024D/745C015A 1999-11-09 Gerald Pfeifer <gerald@pfeifer.com>
@@ -133,16 +141,10 @@ RUN set -ex; \
 	ldconfig -v; \
 	# the libc created by gcc might be too old for a newer Debian
 	# check that the Debian libstdc++ doesn't have newer requirements than the gcc one
-	bash -Eeuo pipefail -xc ' \
-		deb="$(strings /usr/lib/*/libstdc++.so* | grep "^GLIBC" | sort -u)"; \
-		gcc="$(strings /usr/local/lib*/libstdc++.so | grep "^GLIBC" | sort -u)"; \
-{{ if .debian.version == "bookworm" and (env.version | tonumber) >= 14 then ( -}}
-# https://github.com/docker-library/gcc/pull/103#issuecomment-2099134740 (using "comm" to avoid accidental partial matches / hairy "grep" regex)
-		deb="$(comm -23 <(cat <<<"$deb") <(echo "GLIBC_2.16"))"; \
-{{ ) else "" end -}}
-		diff="$(comm -23 <(cat <<<"$deb") <(cat <<<"$gcc"))"; \
-		test -z "$diff"; \
-	'
+	deb="$(readlink -ve /usr/lib/*/libstdc++.so* | head -1)"; \
+	gcc="$(readlink -ve /usr/local/lib*/libstdc++.so | head -1)"; \
+# using LD_PRELOAD to make sure "abidiff" itself doesn't fail with the exact error we're trying to test for 😂😭
+	LD_PRELOAD="$deb" abidiff --no-added-syms "$deb" "$gcc"
 
 # ensure that alternatives are pointing to the new compiler and that old one is no longer used
 RUN set -ex; \


### PR DESCRIPTION
This should be both more reliable and more correct. 👍

As suggested by @jwakely in https://github.com/docker-library/gcc/pull/103 :heart:

I verified this change by building `gcc:10` with the modification of being `FROM buildpack-deps:bookworm` (which fails appropriately because Bookworm defaults to GCC 12).