### PR TITLE
Switch to upstream mirror for scraping version numbers

### DIFF
--- a/10/Dockerfile
+++ b/10/Dockerfile
@@ -38,6 +38,8 @@ ENV GCC_MIRRORS \
 		https://bigsearcher.com/mirrors/gcc/releases \
 		http://www.netgull.com/gcc/releases \
 		https://ftpmirror.gnu.org/gcc \
+# "sourceware.org" is the canonical upstream release host (the host of "gcc.gnu.org")
+		https://sourceware.org/pub/gcc/releases \
 # only attempt the origin FTP as a mirror of last resort
 		ftp://ftp.gnu.org/gnu/gcc
 

--- a/11/Dockerfile
+++ b/11/Dockerfile
@@ -38,6 +38,8 @@ ENV GCC_MIRRORS \
 		https://bigsearcher.com/mirrors/gcc/releases \
 		http://www.netgull.com/gcc/releases \
 		https://ftpmirror.gnu.org/gcc \
+# "sourceware.org" is the canonical upstream release host (the host of "gcc.gnu.org")
+		https://sourceware.org/pub/gcc/releases \
 # only attempt the origin FTP as a mirror of last resort
 		ftp://ftp.gnu.org/gnu/gcc
 

--- a/12/Dockerfile
+++ b/12/Dockerfile
@@ -38,6 +38,8 @@ ENV GCC_MIRRORS \
 		https://bigsearcher.com/mirrors/gcc/releases \
 		http://www.netgull.com/gcc/releases \
 		https://ftpmirror.gnu.org/gcc \
+# "sourceware.org" is the canonical upstream release host (the host of "gcc.gnu.org")
+		https://sourceware.org/pub/gcc/releases \
 # only attempt the origin FTP as a mirror of last resort
 		ftp://ftp.gnu.org/gnu/gcc
 

--- a/13/Dockerfile
+++ b/13/Dockerfile
@@ -38,6 +38,8 @@ ENV GCC_MIRRORS \
 		https://bigsearcher.com/mirrors/gcc/releases \
 		http://www.netgull.com/gcc/releases \
 		https://ftpmirror.gnu.org/gcc \
+# "sourceware.org" is the canonical upstream release host (the host of "gcc.gnu.org")
+		https://sourceware.org/pub/gcc/releases \
 # only attempt the origin FTP as a mirror of last resort
 		ftp://ftp.gnu.org/gnu/gcc
 

--- a/14/Dockerfile
+++ b/14/Dockerfile
@@ -38,6 +38,8 @@ ENV GCC_MIRRORS \
 		https://bigsearcher.com/mirrors/gcc/releases \
 		http://www.netgull.com/gcc/releases \
 		https://ftpmirror.gnu.org/gcc \
+# "sourceware.org" is the canonical upstream release host (the host of "gcc.gnu.org")
+		https://sourceware.org/pub/gcc/releases \
 # only attempt the origin FTP as a mirror of last resort
 		ftp://ftp.gnu.org/gnu/gcc
 

--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -32,6 +32,8 @@ ENV GCC_MIRRORS \
 		https://bigsearcher.com/mirrors/gcc/releases \
 		http://www.netgull.com/gcc/releases \
 		https://ftpmirror.gnu.org/gcc \
+# "sourceware.org" is the canonical upstream release host (the host of "gcc.gnu.org")
+		https://sourceware.org/pub/gcc/releases \
 # only attempt the origin FTP as a mirror of last resort
 		ftp://ftp.gnu.org/gnu/gcc
 

--- a/versions.sh
+++ b/versions.sh
@@ -34,8 +34,7 @@ debianStable="$(awk <<<"$debianStable" '$1 == "Codename:" { print $2; exit }')"
 [ -n "$debianStable" ]
 defaultDebianSuite="$debianStable"
 
-#packagesUrl='https://ftpmirror.gnu.org/gcc/'
-packagesUrl='https://mirrors.kernel.org/gnu/gcc/' # the actual HTML of the page changes based on which mirror we end up hitting, so let's hit a specific one for now... :'(
+packagesUrl='https://sourceware.org/pub/gcc/releases/?C=M;O=D' # the actual HTML of the page changes based on which mirror we end up hitting, *and* sometimes specific mirrors are missing versions, so let's hit the original canonical host for version scraping
 packages="$(wget -qO- "$packagesUrl")"
 
 # our own "supported" window is 18 months from the most recent release because upstream doesn't have a good guideline, but appears to only release maintenance updates for 2-3 years after the initial release
@@ -50,8 +49,8 @@ eols=()
 dateFormat='%Y-%m-%d'
 
 for version in "${versions[@]}"; do
-	fullVersion="$(grep -E '<a href="(gcc-)?'"$version." <<<"$packages" | sed -r 's!.*<a href="(gcc-)?([^"/]+)/?".*!\2!' | sort -V | tail -1)"
-	lastModified="$(grep -Em1 '<a href="(gcc-)?'"$fullVersion"'/"' <<<"$packages" | awk -F '  +' '{ print $2 }')"
+	fullVersion="$(grep -P '<a href="(gcc-)?\Q'"$version."'\E' <<<"$packages" | sed -r 's!.*<a href="(gcc-)?([^"/]+)/?".*!\2!' | sort -V | tail -1)"
+	lastModified="$(grep -Pm1 '<a href="(gcc-)?\Q'"$fullVersion"'\E/"' <<<"$packages" | grep -oPm1 '(?<![0-9])[0-9]{4}-[0-9]{2}-[0-9]{2}(?![0-9])')"
 	lastModified="$(date -d "$lastModified" +"$dateFormat")"
 
 	lastModifiedTime="$(date +'%s' -d "$lastModified")"


### PR DESCRIPTION
Currently, we have a 12.4 release that's published, but not (yet) on the kernel.org mirror, so our version scraping fails to pick it up.

While I feel less bad about scraping the kernel.org mirror load-wise, I think it's probably reasonable for our only-a-couple-times-daily version scraping script to poke the official upstream server to find the official upstream releases without relying on them having propagated to the mirrors yet (especially since it's not downloading the large bits -- just the HTML file listing).