### PR TITLE
Remove mips64le special case (no longer supported)

### DIFF
--- a/generate-stackbrew-library.sh
+++ b/generate-stackbrew-library.sh
@@ -94,9 +94,8 @@ for version; do
 
 	parent="$(awk 'toupper($1) == "FROM" { print $2 }' "$version/Dockerfile")"
 	# no i386 for now: https://github.com/docker-library/gcc/issues/38
-	# no mips64le for now: https://github.com/docker-library/gcc/issues/67
 	# no riscv64 because it takes (way) too long to build
-	arches="$(sed <<<" ${parentRepoToArches[$parent]} " -r -e 's/ i386 / /g' -e 's/ mips64le / /g' -e 's/ riscv64 / /g')"
+	arches="$(sed <<<" ${parentRepoToArches[$parent]} " -r -e 's/ i386 / /g' -e 's/ riscv64 / /g')"
 
 	echo
 	jq -r '"# Last Modified: " + .[env.version].lastModified' versions.json


### PR DESCRIPTION
This can't be merged until https://github.com/docker-library/official-images/pull/21977 is.